### PR TITLE
add processLabels option for runFinal

### DIFF
--- a/config/FCCAnalysisRun.py
+++ b/config/FCCAnalysisRun.py
@@ -147,6 +147,12 @@ def getElement(rdfModule, element, isFinal=False):
                 return {}
             else: print('The option <{}> is not available in presel analysis'.format(element))
 
+        elif element=='processLabels':
+            if isFinal:
+                print('The variable <{}> is optional in your analysis_final.py file return empty dictionary'.format(element))
+                return {}
+            else: print('The option <{}> is not available in presel analysis'.format(element))
+
         elif element=='geometryFile':
             print('The variable <{}> is optional in your analysys.py file, return default value empty string'.format(element))
             if isFinal: print('The option <{}> is not available in final analysis'.format(element))
@@ -765,6 +771,7 @@ def runFinal(rdfModule):
     cutList = getElement(rdfModule,"cutList", True)
     length_cuts_names = max([len(cut) for cut in cutList])
     cutLabels = getElement(rdfModule,"cutLabels", True)
+    processLabels = getElement(rdfModule,"processLabels", True)
 
     # save a table in a separate tex file
     saveTabular = getElement(rdfModule,"saveTabular", True)
@@ -851,9 +858,14 @@ def runFinal(rdfModule):
         tdf_list = []
         count_list = []
         cuts_list = []
-        cuts_list.append(pr)
         eff_list=[]
-        eff_list.append(pr)
+
+        if processLabels:
+            cuts_list.append(processLabels[pr])
+            eff_list.append(processLabels[pr])
+        else:
+            cuts_list.append(pr)
+            eff_list.append(pr)
 
         # Define all histos, snapshots, etc...
         print ('----> Defining snapshots and histograms')

--- a/examples/FCCee/bsm/LLPs/DisplacedHNL/analysis_final.py
+++ b/examples/FCCee/bsm/LLPs/DisplacedHNL/analysis_final.py
@@ -32,6 +32,22 @@ processList = {
     'eenu_90GeV_1p41e-6Ve':{},
 }
 
+###Dictionary for prettier names of processes (optional)
+processLabels = {
+    #backgrounds
+    'p8_ee_Zee_ecm91':"Z $\rightarrow$ ee",
+    'p8_ee_Ztautau_ecm91':"Z $\rightarrow \tau \tau$",
+    'p8_ee_Zbb_ecm91':"Z $\rightarrow$ bb",
+    'p8_ee_Zcc_ecm91':"Z $\rightarrow$ cc",
+    'p8_ee_Zuds_ecm91':"Z $\rightarrow$ uds",
+
+    #signals
+    'eenu_30GeV_1p41e-6Ve': "$m_N =$ 30 GeV, $|V_{eN}| =  1.41 * 10^{-6}$",
+    'eenu_50GeV_1p41e-6Ve': "$m_N =$ 50 GeV, $|V_{eN}| =  1.41 * 10^{-6}$",
+    'eenu_70GeV_1p41e-6Ve': "$m_N =$ 70 GeV, $|V_{eN}| =  1.41 * 10^{-6}$",
+    'eenu_90GeV_1p41e-6Ve': "$m_N =$ 90 GeV, $|V_{eN}| =  1.41 * 10^{-6}$",
+}
+
 #Link to the dictonary that contains all the cross section information etc...
 procDict = "FCCee_procDict_spring2021_IDEA.json"
 


### PR DESCRIPTION
Building on #1 , this PR adds another option when running `fccanalysis final analysis_final.py`, namely,  the option to rename the processes in an easier-to-read way for the table (with the variable `processLabels`).

An example of how to use these new variables is provided in `examples/FCCee/bsm/LLPs/DisplacedHNL/analysis_final.py`