### PR TITLE
Including HNL sample generation and plotting code

### DIFF
--- a/examples/FCCee/bsm/LLPs/DisplacedHNL/HNL_sample_creation/mg5_proc_card_HNL_Dirac_eenu_20GeV_1e-3Ve.dat
+++ b/examples/FCCee/bsm/LLPs/DisplacedHNL/HNL_sample_creation/mg5_proc_card_HNL_Dirac_eenu_20GeV_1e-3Ve.dat
@@ -1,0 +1,68 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 2.7.3                 2020-06-21         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+#This card was originally made by suchita Kulkarni
+#contact suchita.kulkarni@cern.ch
+#Then edited by Dimitri Moulin
+#contact dimitri.moulin@etu.unige.ch
+
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define p = g u c d s u~ c~ d~ s~
+define j = g u c d s u~ c~ d~ s~
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model SM_HeavyN_Dirac_CKM_Masses_LO
+generate e+ e- > n1 ve~ , (n1 > ve e+ e-)
+add process e+ e- > n1~ ve , (n1~ > ve~ e+ e-)
+output HNL_Dirac_eenu_20GeV_1e-3Ve
+launch HNL_Dirac_eenu_20GeV_1e-3Ve
+done
+# set to electron beams (0 for ele, 1 for proton)
+set lpp1 0
+set lpp2 0
+set ebeam1 45.594
+set ebeam2 45.594
+set no_parton_cut
+# Here I set mass of the electron HNL
+set mn1 20
+# set mass of muon HNL, made heavy here
+set mn2 10000
+# set mass of tau HNL, made heavy here
+set mn3 10000
+# set electron mixing angle
+set ven1 1e-3
+# this is important, set the decay width of HNL flavour of interest to auto
+# if this is not done, lifetime calculations won'e be right
+set WN1 auto
+set time_of_flight 0
+set nevents 10000
+done

--- a/examples/FCCee/bsm/LLPs/DisplacedHNL/HNL_sample_creation/mg5_proc_card_HNL_Dirac_ejj_20GeV_1e-3Ve.dat
+++ b/examples/FCCee/bsm/LLPs/DisplacedHNL/HNL_sample_creation/mg5_proc_card_HNL_Dirac_ejj_20GeV_1e-3Ve.dat
@@ -1,0 +1,69 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 2.7.3                 2020-06-21         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+#This card was originally made by suchita Kulkarni
+#contact suchita.kulkarni@cern.ch
+#Then edited by Dimitri Moulin
+#contact dimitri.moulin@etu.unige.ch
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define p = g u c d s u~ c~ d~ s~
+define j = g u c d s u~ c~ d~ s~
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model SM_HeavyN_Dirac_CKM_Masses_LO
+generate e+ e- > n1 ve~ , (n1 >  ve e+ e-)
+add process e+ e- > n1~ ve , (n1~ > e+ e- ve~)
+add process e+ e- > n1~ ve , (n1~ > e+ j j)
+add process e+ e- > n1 ve~ , (n1 > e- j j )
+output HNL_Dirac_ejj_20GeV_1e-3Ve
+launch HNL_Dirac_ejj_20GeV_1e-3Ve
+done
+# set to electron beams (0 for ele, 1 for proton)
+set lpp1 0
+set lpp2 0
+set ebeam1 45.594
+set ebeam2 45.594
+set no_parton_cut
+# Here I set mass of the electron HNL
+set mn1 20
+# set mass of muon HNL, made heavy here
+set mn2 10000
+# set mass of tau HNL, made heavy here
+set mn3 10000
+# set electron mixing angle
+set ven1 1e-3
+# this is important, set the decay width of HNL flavour of interest to auto
+# if this is not done, lifetime calculations won'e be right
+set WN1 auto
+set time_of_flight 0
+set nevents 10000
+done

--- a/examples/FCCee/bsm/LLPs/DisplacedHNL/HNL_sample_creation/mg5_proc_card_HNL_Majorana_ejj_20GeV_1e-3Ve.dat
+++ b/examples/FCCee/bsm/LLPs/DisplacedHNL/HNL_sample_creation/mg5_proc_card_HNL_Majorana_ejj_20GeV_1e-3Ve.dat
@@ -1,0 +1,73 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 2.7.3                 2020-06-21         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+#This card was originally made by suchita Kulkarni
+#contact suchita.kulkarni@cern.ch
+#Then modified by Dimitri Moulin
+#contact dimitri.moulin@etu.unige.ch
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define p = g u c d s u~ c~ d~ s~
+define j = g u c d s u~ c~ d~ s~
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model SM_HeavyN_CKM_AllMasses_LO
+generate e+ e-  > n1 ve , (n1 > ve e+ e-)
+add process e+ e- > n1 ve~ , (n1 > ve~ e+ e-)
+add process e+ e- > n1 ve , (n1 > e+ e- ve~)
+add process e+ e- > n1 ve~ , (n1 > e- e+ ve)
+add process e+ e- > n1 ve , (n1 > e+ j j)
+add process e+ e- > n1 ve , (n1 > e- j j)
+add process e+ e- > n1 ve~ , (n1 > e+ j j)
+add process e+ e- > n1 ve~ , (n1 > e- j j)
+output HNL_Majorana_ejj_20GeV_1e-3Ve
+launch HNL_Majorana_ejj_20GeV_1e-3Ve
+done
+# set to electron beams (0 for ele, 1 for proton)
+set lpp1 0
+set lpp2 0
+set ebeam1 45.594
+set ebeam2 45.594
+set no_parton_cut
+# Here I set mass of the electron HNL
+set mn1 20
+# set mass of muon HNL, made heavy here
+set mn2 10000
+# set mass of tau HNL, made heavy here
+set mn3 10000
+# set electron mixing angle
+set ven1 1e-3
+# this is important, set the decay width of HNL flavour of interest to auto
+# if this is not done, lifetime calculations won'e be right
+set WN1 auto
+set time_of_flight 0
+set nevents 10000
+done

--- a/examples/FCCee/bsm/LLPs/DisplacedHNL/plotting_tools/Readme.md
+++ b/examples/FCCee/bsm/LLPs/DisplacedHNL/plotting_tools/Readme.md
@@ -1,0 +1,41 @@
+# How to run the code
+<details>
+<summary>Show/Hide Table of Contents</summary>
+
+[[_TOC_]]
+
+</details>
+
+## Overview
+
+This text file describes how to produce ratio plots for comparing Dirac and Majorana HNLs.
+Below is a description of how to modify 'make_selection.py' and 'make_plots.py'.
+
+## make_selection.py
+This script is used to select the variables to be plotted. It returns a .root file containing the selected variables histograms. You must run it both for your Dirac and Majorana samples. 
+### How to adapt it to your needs
+First, specify the path of the input file. The input file corresponds to the output file of 'analysis_final.py'. The path should look like :
+'/afs/cern.ch/user/d/dimoulin/FCCAnalyses_new/Analysis/outputs/HNL_Majorana_ejj_20GeV_1e-3Ve/output_finalSel/HNL_Majorana_ejj_20GeV_1e-3Ve_selNone_histo.root'
+Next, specify the variables to be plotted, e.g if you want to plot the reconstructed electron energy (RecoElectron_e) you must include the line :
+'histSelect.WriteObject(hist_file.Get("RecoElectron_e"), "RecoElectron_e")'
+Finally, specify the name of the output file e.g : 
+'output_file = "histMajorana_ejj_Select.root"'
+You can then run the script using 'python make_selection.py'
+
+## make_plots.py
+This script produces ratio plots of the previously selected variables.
+### How to adapt it to your needs
+You need to specify the path to the selection files :
+'input_file_Dirac = 'histDirac_ejj_Select.root''
+'input_file_Majorana = 'histMajorana_ejj_Select.root''
+As well as the output directory : 
+'output_dir = "20GeV_ejj_plots/"'
+
+Then you must add the selected variables to the 'variables_list'.
+
+### Miscellaneous
+You can modify the legend by modifying the second entry of 'files_list', as well as the colors of the graphs by modifying the 'colors' list. Finally, the plots are currently saved in .png, you can modify this to any supported extension you like.
+
+
+
+

--- a/examples/FCCee/bsm/LLPs/DisplacedHNL/plotting_tools/make_plots.py
+++ b/examples/FCCee/bsm/LLPs/DisplacedHNL/plotting_tools/make_plots.py
@@ -8,9 +8,12 @@ ROOT.gStyle.SetOptStat(0)
 ROOT.gStyle.SetOptTitle(0)
 
 
-output_dir = "outputs/20GeV_ejj_plots/"
+output_dir = "test_log_false/"
 input_file_Dirac = 'histDirac_ejj_Select.root'
 input_file_Majorana = 'histMajorana_ejj_Select.root'
+
+# Set plot log-scale plots, default: False
+log_scale = False
 
 if not os.path.exists(output_dir):
     os.mkdir(output_dir)
@@ -94,11 +97,12 @@ variables_list = [
 ]
 
 files_list = [
-    [input_file_Majorana , 'Majorana 20 GeV semi-leptonic'],
-    [input_file_Dirac , 'Dirac 20 GeV semi-leptonic']
+    [input_file_Majorana , 'Majorana 20 GeV semi-leptonic', 'Majorana'],
+    [input_file_Dirac , 'Dirac 20 GeV semi-leptonic', 'Dirac']
 ]
 
 legend_list = [f[1] for f in files_list]
+ratio_list = [f[2] for f in files_list]
 colors = [609, 856, 410, 801, 629, 879, 602, 921, 622]
 
 def make_plot(h_list, plot_info, legend_list):
@@ -109,6 +113,7 @@ def make_plot(h_list, plot_info, legend_list):
 
     pad1.SetFillColor(0)
     pad1.SetBottomMargin(0.01)
+    if log_scale == True : pad1.SetLogy()
     pad1.SetTickx()
     pad1.SetTicky()
     pad1.Draw()
@@ -137,7 +142,7 @@ def make_plot(h_list, plot_info, legend_list):
         h.SetLineColor(colors[ih])
         h.SetLineWidth(3)
         h.GetXaxis().SetTitle(plot_info[1])        
-        h.GetYaxis().SetTitle(plot_info[2])
+        h.GetYaxis().SetTitle(plot_info[2]) if log_scale == False else h.GetYaxis().SetTitle("log " + plot_info[2])
         h.GetYaxis().SetTitleSize(h.GetYaxis().GetTitleSize()*1.5)
         h.GetYaxis().SetTitleOffset(0.8)
         h.SetMaximum(1.25*h_max)
@@ -163,7 +168,7 @@ def make_plot(h_list, plot_info, legend_list):
         h.SetMaximum(1.5)
         h.SetMinimum(0.5)
 
-        h.GetYaxis().SetTitle("Ratio to "+legend_list[0])
+        h.GetYaxis().SetTitle("Ratio to "+ratio_list[0])
         h.GetYaxis().SetLabelSize(h.GetYaxis().GetLabelSize()*1.6)
         h.GetYaxis().SetLabelOffset(0.01)
         h.GetYaxis().SetTitleSize(h.GetYaxis().GetTitleSize()*1.6)

--- a/examples/FCCee/bsm/LLPs/DisplacedHNL/plotting_tools/make_plots.py
+++ b/examples/FCCee/bsm/LLPs/DisplacedHNL/plotting_tools/make_plots.py
@@ -1,0 +1,192 @@
+import ROOT
+import os
+# plots don't appear while you run
+ROOT.gROOT.SetBatch(0)
+# no stat box on plots
+ROOT.gStyle.SetOptStat(0)
+# no title shown 
+ROOT.gStyle.SetOptTitle(0)
+
+
+output_dir = "outputs/20GeV_ejj_plots/"
+input_file_Dirac = 'histDirac_ejj_Select.root'
+input_file_Majorana = 'histMajorana_ejj_Select.root'
+
+if not os.path.exists(output_dir):
+    os.mkdir(output_dir)
+    print("Directory ",output_dir," Created ")
+else:    
+    print("Directory ",output_dir," already exists")
+
+# list of lists
+# each internal list: hist name, x title, y title, rebin (if needed)
+variables_list = [
+     ["RecoElectron_pt", "Reco electron pt", "Entries", 3],
+     ["RecoElectron_phi", "Reco Electron phi", "Entries", 3],
+     ["RecoElectron_theta", "Reco Electron theta", "Entries", 3],
+     ["RecoElectron_e", "Reco Electron energy", "Entries", 3],
+     ["RecoMissingEnergy_e", "Reco Missing_e", "Entries", 3],
+     ["RecoMissingEnergy_pt", "Reco Missing_pt", "Entries", 3],
+     ["RecoMissingEnergy_p", "Reco Missing_p", "Entries", 3],
+     ["RecoMissingEnergy_px", "Reco Missing_px", "Entries", 3],
+     ["RecoMissingEnergy_py", "Reco Missing_py", "Entries", 3],
+     ["RecoMissingEnergy_pz", "Reco Missing_pz", "Entries", 3],
+     ["RecoMissingEnergy_eta", "Reco Missing_eta", "Entries", 3],
+     ["RecoMissingEnergy_theta", "Reco Missing_theta", "Entries", 3],
+     ["RecoMissingEnergy_phi", "Reco Missing_phi", "Entries", 3],
+     
+     ["n_RecoJets", "Number of RecoJets", "Entries", 3],
+     ["RecoJet_e", "Reco Jet energy", "Entries", 3],
+     ["RecoJet_p", "Reco Jet p", "Entries", 3],
+     ["RecoJet_pt", "Reco Jet pt", "Entries", 3],
+     ["RecoJet_pz", "Reco Jet pz", "Entries", 3],
+     ["RecoJet_eta", "Reco Jet eta", "Entries", 3],
+     ["RecoJet_theta", "Reco Jet theta", "Entries", 3],
+     ["RecoJet_phi", "Reco Jet phi", "Entries", 3],
+     ["RecoJet_charge", "Reco Jet charge", "Entries", 3],
+     ["RecoJetTrack_absD0", "Reco Jet abs_DO", "Entries", 3],
+     ["RecoJetTrack_absZ0", "Reco Jet abs_Z0", "Entries", 3],
+     ["RecoJetTrack_absD0sig", "Reco Jet sigma(abs_D0)", "Entries", 3],
+     ["RecoJetTrack_absZ0sig", "Reco Jet sigma(abs_Z0)", "Entries", 3],
+     ["RecoJetTrack_D0cov", "Reco Jet cov(D0)", "Entries", 3],
+     ["RecoJetTrack_Z0cov", "Reco Jet cov(Z0)", "Entries", 3],
+
+
+#    ['hnlLT', 'Lifetime [s]', 'Entries'],
+#    ['angsepR', 'Reco Cos#theta ee', 'Entries', 5],
+#    ['angsep', 'Cos#theta ee', 'Entries', 5],
+#    ['et', 'Missing energy [GeV]', 'Entries'],
+#    ['eTruthE', 'Electron energy [GeV]', 'Entries'] ,
+#    ['eTruthP', 'Positron energy [GeV]', 'Entries'] ,
+#    ['eRecoE', 'Reco Electron energy [GeV]', 'Entries'] ,
+#    ['eRecoP', 'Reco Positron energy [GeV]', 'Entries'] ,
+#    ['etaRE', 'Reco electron #eta', 'Entries'] ,
+#    ['etaRP', 'Reco positron #eta', 'Entries'] ,
+#    ['phiRE', 'Reco electron #phi', 'Entries'] ,
+#    ['phiRP', 'Reco positron #phi', 'Entries'] ,
+#    ['deletaR', 'Reco del eta ee', 'Entries'] ,
+#    ['delphiR', 'Reco del phi ee', 'Entries'] ,
+#    ['delRR', 'Reco del R ee', 'Entries'] ,
+#    ['etaE', 'electron #eta', 'Entries'] ,
+#    ['etaP', 'positron #eta', 'Entries'] ,
+#    ['phiE', 'electron #phi', 'Entries'] ,
+#    ['phiP', 'positron #phi', 'Entries'] ,
+#    ['deleta', 'del eta ee', 'Entries'] ,
+#    ['delphi', 'del phi ee', 'Entries'] ,
+#    ['delR', 'del R ee', 'Entries'] ,
+#    ['xmRE', 'Reco Px electron [GeV]', 'Entries'] ,
+#    ['ymRE', 'Reco Py electron [GeV]', 'Entries'] ,
+#    ['zmRE', 'Reco Pz electron [GeV]', 'Entries'] ,
+#    ['xmRP', 'Reco Px positron [GeV]', 'Entries'] ,
+#    ['ymRP', 'Reco Py positron (GeV', 'Entries'] ,
+#    ['zmRP', 'Reco Pz positron [GeV]', 'Entries'] ,
+#    ['tmRE', 'Reco pT electron [GeV]', 'Entries'] ,
+#    ['tmRP', 'Reco pT positron [GeV]', 'Entries'] ,
+#    ['xmTE', 'Px electron [GeV]', 'Entries'] ,
+#    ['ymTE', 'Py electron [GeV]', 'Entries'] ,
+#    ['zmTE', 'Pz electron [GeV]', 'Entries'] ,
+#    ['xmTP', 'Px positron [GeV]', 'Entries'] ,
+#    ['ymTP', 'Py positron [GeV]', 'Entries'] ,
+#    ['zmTP', 'Pz positron [GeV]', 'Entries'] ,
+#    ['tmTE', 'pT electron [GeV]', 'Entries'] ,    
+#    ['tmTP', 'pT positron [GeV]', 'Entries'] ,
+#   ['dispvrtx', 'displaced vetex [m]', 'Entries']
+]
+
+files_list = [
+    [input_file_Majorana , 'Majorana 20 GeV semi-leptonic'],
+    [input_file_Dirac , 'Dirac 20 GeV semi-leptonic']
+]
+
+legend_list = [f[1] for f in files_list]
+colors = [609, 856, 410, 801, 629, 879, 602, 921, 622]
+
+def make_plot(h_list, plot_info, legend_list):
+   #  print('looking at histogram:', plot_info[0])
+    c = ROOT.TCanvas("can"+plot_info[0],"can"+plot_info[0],600,600)
+    pad1 = ROOT.TPad("pad1", "pad1",0.0,0.35,1.0,1.0,21)
+    pad2 = ROOT.TPad("pad2", "pad2",0.0,0.0,1.0,0.35,22)
+
+    pad1.SetFillColor(0)
+    pad1.SetBottomMargin(0.01)
+    pad1.SetTickx()
+    pad1.SetTicky()
+    pad1.Draw()
+
+    pad2.SetFillColor(0)
+    pad2.SetTopMargin(0.01)
+    pad2.SetBottomMargin(0.3)
+    pad2.Draw()
+
+    leg = ROOT.TLegend(0.55, 0.7, 0.87, 0.87)
+    leg.SetFillStyle(0)
+    leg.SetLineWidth(0)
+
+    h_max = 0
+    for ih,h in enumerate(h_list):
+        leg.AddEntry(h, legend_list[ih])
+        if len(plot_info)>3:
+            h.Rebin(plot_info[3])
+        if h.GetMaximum() > h_max:
+            h_max = h.GetMaximum()
+        h.Sumw2()
+
+    # Draw in the top panel
+    pad1.cd()
+    for ih,h in enumerate(h_list):
+        h.SetLineColor(colors[ih])
+        h.SetLineWidth(3)
+        h.GetXaxis().SetTitle(plot_info[1])        
+        h.GetYaxis().SetTitle(plot_info[2])
+        h.GetYaxis().SetTitleSize(h.GetYaxis().GetTitleSize()*1.5)
+        h.GetYaxis().SetTitleOffset(0.8)
+        h.SetMaximum(1.25*h_max)
+        h.Draw('same')
+        h.Draw('same E')
+    leg.Draw()
+    pad1.RedrawAxis()
+
+    # build ratios
+    h_ratios = []
+    for ih,h in enumerate(h_list):
+        if ih == 0:
+            h_ratios.append(h.Clone('h_ratio_0'))
+            for ibin in range(-1, h.GetNbinsX()+1):
+                h_ratios[0].SetBinContent(ibin,1)
+        else:
+            h_ratios.append(h.Clone('h_ratio_'+str(ih)))
+            h_ratios[ih].Divide(h_list[0])
+
+    # draw in the bottom panel
+    pad2.cd()
+    for ih,h in enumerate(h_ratios):
+        h.SetMaximum(1.5)
+        h.SetMinimum(0.5)
+
+        h.GetYaxis().SetTitle("Ratio to "+legend_list[0])
+        h.GetYaxis().SetLabelSize(h.GetYaxis().GetLabelSize()*1.6)
+        h.GetYaxis().SetLabelOffset(0.01)
+        h.GetYaxis().SetTitleSize(h.GetYaxis().GetTitleSize()*1.6)
+        h.GetYaxis().SetTitleOffset(0.5)
+
+        h.GetXaxis().SetLabelSize(h.GetXaxis().GetLabelSize()*2.3)
+        #h.GetXaxis().SetLabelOffset(0.02)
+        h.GetXaxis().SetTitleSize(h.GetXaxis().GetTitleSize()*3)
+        h.GetXaxis().SetTitleOffset(1.05)
+
+        h.Draw('hist same')
+        if ih>0:
+            h.Draw('same E')
+    c.SaveAs(output_dir + plot_info[0]+'.png')
+    return
+
+for plot_info in variables_list:
+    h_list = []
+    print('looking at histogram:', plot_info[0])
+    for ifile,fil in enumerate(files_list):
+        f = ROOT.TFile.Open(fil[0])
+        h = f.Get(plot_info[0])
+        h.SetDirectory(0)
+        h_list.append(h)
+        f.Close()
+    make_plot(h_list, plot_info, legend_list)

--- a/examples/FCCee/bsm/LLPs/DisplacedHNL/plotting_tools/make_selection.py
+++ b/examples/FCCee/bsm/LLPs/DisplacedHNL/plotting_tools/make_selection.py
@@ -1,0 +1,56 @@
+import ROOT
+input_path = "/afs/cern.ch/user/d/dimoulin/FCCAnalyses_new/Analysis/outputs/HNL_Majorana_20GeV_1e-3Ve_jets_n50000/output_finalSel/HNL_Majorana_20GeV_1e-3Ve_jets_n50000_selNone_histo.root"
+output_file = "histMajorana_ejj_Select.root"
+
+hist_file = ROOT.TFile.Open(input_path)
+#hist_file = ROOT.TFile.Open("../outputs/HNL_Majorana_20GeV_1e-3Ve/HNL_Majorana_20GeV_1e-3Ve_jets_selNone_histo.root")
+histSelect = ROOT.TFile.Open(output_file, "RECREATE")
+
+#Object variables
+histSelect.WriteObject(hist_file.Get("RecoElectron_pt"), "RecoElectron_pt")
+histSelect.WriteObject(hist_file.Get("RecoElectron_phi"), "RecoElectron_phi")
+histSelect.WriteObject(hist_file.Get("RecoElectron_theta"), "RecoElectron_theta")
+histSelect.WriteObject(hist_file.Get("RecoElectron_e"), "RecoElectron_e")
+histSelect.WriteObject(hist_file.Get("RecoMissingEnergy_e"), "RecoMissingEnergy_e")
+histSelect.WriteObject(hist_file.Get("RecoMissingEnergy_p"), "RecoMissingEnergy_p")
+histSelect.WriteObject(hist_file.Get("RecoMissingEnergy_pt"), "RecoMissingEnergy_pt")
+histSelect.WriteObject(hist_file.Get("RecoMissingEnergy_px"), "RecoMissingEnergy_px")
+histSelect.WriteObject(hist_file.Get("RecoMissingEnergy_py"), "RecoMissingEnergy_py")
+histSelect.WriteObject(hist_file.Get("RecoMissingEnergy_pz"), "RecoMissingEnergy_pz")
+histSelect.WriteObject(hist_file.Get("RecoMissingEnergy_eta"), "RecoMissingEnergy_eta")
+histSelect.WriteObject(hist_file.Get("RecoMissingEnergy_theta"), "RecoMissingEnergy_theta")
+histSelect.WriteObject(hist_file.Get("RecoMissingEnergy_phi"), "RecoMissingEnergy_phi")
+
+# Jet variables 
+histSelect.WriteObject(hist_file.Get("n_RecoJets"), "n_RecoJets")
+histSelect.WriteObject(hist_file.Get("RecoJet_e"), "RecoJet_e")
+histSelect.WriteObject(hist_file.Get("RecoJet_p"), "RecoJet_p")
+histSelect.WriteObject(hist_file.Get("RecoJet_pt"), "RecoJet_pt")
+histSelect.WriteObject(hist_file.Get("RecoJet_pz"), "RecoJet_pz")
+histSelect.WriteObject(hist_file.Get("RecoJet_eta"), "RecoJet_eta")
+histSelect.WriteObject(hist_file.Get("RecoJet_theta"), "RecoJet_theta")
+histSelect.WriteObject(hist_file.Get("RecoJet_phi"), "RecoJet_phi")
+histSelect.WriteObject(hist_file.Get("RecoJet_charge"), "RecoJet_charge")
+histSelect.WriteObject(hist_file.Get("RecoJetTrack_absD0"), "RecoJetTrack_absD0")
+histSelect.WriteObject(hist_file.Get("RecoJetTrack_absZ0"), "RecoJetTrack_absZ0")
+histSelect.WriteObject(hist_file.Get("RecoJetTrack_absD0sig"), "RecoJetTrack_absD0sig")
+histSelect.WriteObject(hist_file.Get("RecoJetTrack_absZ0sig"), "RecoJetTrack_absZ0sig")
+histSelect.WriteObject(hist_file.Get("RecoJetTrack_D0cov"), "RecoJetTrack_D0cov")
+histSelect.WriteObject(hist_file.Get("RecoJetTrack_Z0cov"), "RecoJetTrack_Z0cov")
+#histSelect.WriteObject(hist_file.Get(""), "")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Added the mg5 proc_cards.dat for generation of Dirac and Majorana samples for ejj, eenu processes. 
Also added a plotting_tools directory containing two scripts and a Readme.md for how to run these scripts. The plotting directory can be used to produce comparison plots between Majorana and Dirac HNLs by including the ratio between the two.
