### PR TITLE
Add exotic higgs decays dv finder code

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/VertexingUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/VertexingUtils.h
@@ -35,6 +35,7 @@ namespace VertexingUtils{
     ROOT::VecOps::RVec< TVector3 >  updated_track_momentum_at_vertex;
     ROOT::VecOps::RVec< TVectorD >  updated_track_parameters;
     ROOT::VecOps::RVec<float> final_track_phases;
+    ROOT::VecOps::RVec<edm4hep::TrackState> tracks;   // added to keep track of the tracks that are associated to each vertex, used in SV finder from LCFI+ to merge vertices
   };
 
   /// Structure to keep useful information that is related to the V0
@@ -74,6 +75,23 @@ namespace VertexingUtils{
 
   /// Retrieve the number of reconstructed vertices from the collection of vertex object
   int get_Nvertex( ROOT::VecOps::RVec<FCCAnalysesVertex> TheVertexColl );
+
+  /// Merge vertices that are within 10*error of position or 1 mm, of each other
+  ROOT::VecOps::RVec<FCCAnalysesVertex> mergeVertices ( ROOT::VecOps::RVec<FCCAnalysesVertex> vertices_in );
+
+  /// selection of tracks based on the transverse momentum pT
+  struct sel_pt_tracks {
+    sel_pt_tracks(float arg_min_pt);
+    float m_min_pt = 0;
+    ROOT::VecOps::RVec<edm4hep::TrackState> operator() (ROOT::VecOps::RVec<edm4hep::TrackState> in);
+  };
+
+  /// selection of tracks based on the impact paramter d0
+  struct sel_d0_tracks {
+    sel_d0_tracks(float arg_min_d0);
+    float m_min_d0 = 0;
+    ROOT::VecOps::RVec<edm4hep::TrackState> operator() (ROOT::VecOps::RVec<edm4hep::TrackState> in);
+  };
 
   /// Retrieve a single FCCAnalyses vertex from the collection of vertex object
   FCCAnalysesVertex get_FCCAnalysesVertex(ROOT::VecOps::RVec<FCCAnalysesVertex> TheVertexColl, int index );

--- a/analyzers/dataframe/src/VertexFinderLCFIPlus.cc
+++ b/analyzers/dataframe/src/VertexFinderLCFIPlus.cc
@@ -304,6 +304,9 @@ ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> findSVfromTracks(ROOT::Vec
     }
     VertexingUtils::FCCAnalysesVertex sec_vtx = VertexFitterSimple::VertexFitter_Tk(2, tr_vtx_fin); // flag 2 for SVs
 
+    // save the tracks that are used to fit the SV
+    sec_vtx.tracks = tr_vtx_fin;
+
     // see if we can also get indices in the reco collection (for tracks forming an SV)
     //sec_vtx.reco_ind = VertexFitterSimple::get_reco_ind(recoparticles,thetracks); // incorrect
 


### PR DESCRIPTION
- Modifies the structur FCCAnalysVertex and VertexFinderLCFIplus to store information of the tracks
- Added three functions in VertexingUtils related to finding DVs