### PR TITLE
ALPs in FCCAnalyses 

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/myUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/myUtils.h
@@ -108,14 +108,28 @@ namespace myUtils{
     ROOT::VecOps::RVec<int> operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop);
   };
 
-struct selMC_leg{
-  selMC_leg( int arg_idx );
-  int m_idx;
-  ROOT::VecOps::RVec<edm4hep::MCParticleData> operator() (ROOT::VecOps::RVec<int> list_of_indices,
-							  ROOT::VecOps::RVec<edm4hep::MCParticleData> in) ;
-};
+  struct selMC_leg{
+    selMC_leg( int arg_idx );
+    int m_idx;
+    ROOT::VecOps::RVec<edm4hep::MCParticleData> operator() (ROOT::VecOps::RVec<int> list_of_indices,
+							    ROOT::VecOps::RVec<edm4hep::MCParticleData> in) ;
+  };
 
-ROOT::VecOps::RVec<float> get_both_scalars(ROOT::VecOps::RVec<float> scalar1_value, ROOT::VecOps::RVec<float> scalar2_value);
+  struct selRP_leg{
+    selRP_leg( int idx );
+    int m_idx;
+    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> BsRecoParticles);
+  };
+
+  struct selRP_leg_atVertex{
+    selRP_leg_atVertex( int idx );
+    int m_idx;
+    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> BsRecoParticles,
+								       VertexingUtils::FCCAnalysesVertex BsDecayVertex,
+								       ROOT::VecOps::RVec<edm4hep::TrackState> tracks) ;
+  };
+
+  ROOT::VecOps::RVec<float> get_both_scalars(ROOT::VecOps::RVec<float> scalar1_value, ROOT::VecOps::RVec<float> scalar2_value);
 
   ROOT::VecOps::RVec<edm4hep::TrackState> get_pseudotrack(ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
 							  ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop);

--- a/examples/FCCee/bsm/LLPs/ALPs/ALP_sample_creation/ALP_pythia.cmnd
+++ b/examples/FCCee/bsm/LLPs/ALPs/ALP_sample_creation/ALP_pythia.cmnd
@@ -1,7 +1,7 @@
 ! File: ALP_pythia.cmd
 Random:setSeed = on
 Main:timesAllowErrors = 10         ! how many aborts before run stops
-Main:numberOfEvents = 10000         ! number of events to generate
+Main:numberOfEvents = 100000         ! number of events to generate
 
 
 ! 2) Settings related to output in init(), next() and stat().
@@ -11,7 +11,7 @@ Next:numberCount = 100             ! print message every n events
 
 Beams:frameType = 4                ! read info from a LHEF
 ! Change the LHE file here
-Beams:LHEF = ALP_test.lhe
+Beams:LHEF = ALP_Z_aa_1GeV_cYY_0p5.lhe
 
 ! 3) Settings for the event generation process in the Pythia8 library.
 PartonLevel:ISR = on               ! initial-state radiation

--- a/examples/FCCee/bsm/LLPs/ALPs/ALP_sample_creation/runPythiaDelphes.sh
+++ b/examples/FCCee/bsm/LLPs/ALPs/ALP_sample_creation/runPythiaDelphes.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# quick command to run DelphesPythia8_EDM4HEP
+# needs one input for the name of the output root-file
+
+DelphesPythia8_EDM4HEP ../../../../../../../FCC-config/FCCee/Delphes/card_IDEA.tcl ../../../../../../../FCC-config/FCCee/Delphes/edm4hep_IDEA.tcl ALP_pythia.cmnd $1

--- a/examples/FCCee/bsm/LLPs/ALPs/ALP_sample_creation/runPythiaDephies.sh
+++ b/examples/FCCee/bsm/LLPs/ALPs/ALP_sample_creation/runPythiaDephies.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# quick command to run DelphesPythia8_EDM4HEP
-# needs one input for the name of the output root-file
-
-DelphesPythia8_EDM4HEP ../../../../../../FCC-config/FCCee/Delphes/card_IDEA.tcl ../../../../../../FCC-config/FCCee/Delphes/edm4hep_IDEA.tcl ALP_pythia.cmnd $1

--- a/examples/FCCee/bsm/LLPs/ALPs/analysis_final.py
+++ b/examples/FCCee/bsm/LLPs/ALPs/analysis_final.py
@@ -1,0 +1,287 @@
+#Input directory where the files produced at the stage1 level are
+inputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/ALPs_3photons/winter2023/output_stage1/"
+#inputDir = "/eos/user/j/jalimena/FCCeeLLP/"
+#inputDir = "output_stage1/"
+
+#Output directory where the files produced at the final-selection level are
+outputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/ALPs_3photons/winter2023/output_finalSel/"
+#outputDir  = "output_finalSel/"
+
+#Integrated luminosity for scaling number of events (required only if setting doScale to true)
+#intLumi = 150e6 #pb^-1
+
+#Scale event yields by intLumi and cross section (optional)
+#doScale = True
+
+#Save event yields in a table (optional)
+saveTabular = True
+
+processList = {
+    #run over the full statistics from stage1
+
+    #backgrounds
+    #'p8_ee_Zee_ecm91':{},
+
+    #signals
+    'ALP_Z_aa_1GeV_cYY_0p5':{},
+}
+
+###Dictionary for prettier names of processes (optional)
+processLabels = {
+    #backgrounds
+    #'p8_ee_Zee_ecm91':"Z $\rightarrow$ ee",
+
+    #signals
+    'ALP_Z_aa_1GeV_cYY_0p5': "$m_ALP =$ 1 GeV, $c_{YY} = 0.5$",
+}
+
+#Link to the dictonary that contains all the cross section information etc...
+procDict = "FCCee_procDict_spring2021_IDEA.json"
+
+#Add MySample_p8_ee_ZH_ecm240 as it is not an offical process
+procDictAdd={
+    "ALP_Z_aa_1GeV_cYY_0p5": {"numberOfEvents": 100000, "sumOfWeights": 100000, "crossSection": 2.744e-05, "kfactor": 1.0, "matchingEfficiency": 1.0},
+}
+
+#Number of CPUs to use
+nCPUS = 2
+
+#produces ROOT TTrees, default is False
+doTree = False
+
+###Dictionnay of the list of cuts. The key is the name of the selection that will be added to the output file
+cutList = {
+    "selNone": "n_RecoTracks > -1",
+    "sel0": "GenALP_mass.size() > 0",
+    "sel1": "GenALP_mass.size() > 0 && n_RecoElectrons > 1",
+}
+
+###Dictionary for prettier names of cuts (optional)
+cutLabels = {
+    "selNone": "Before selection",
+    "sel0": "Good GEN ALP mass",
+    "sel1": "Good GEN ALP mass and 2 reco electrons",
+}
+
+###Dictionary for the ouput variable/hitograms. The key is the name of the variable in the output files. "name" is the name of the variable in the input file, "title" is the x-axis label of the histogram, "bin" the number of bins of the histogram, "xmin" the minimum x-axis value and "xmax" the maximum x-axis value.
+histoList = {
+    #gen variables
+    "All_n_GenALP":                    {"name":"All_n_GenALP",                   "title":"Total number of gen ALPs",                   "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    "AllGenALP_mass":                  {"name":"AllGenALP_mass",                 "title":"All gen ALP mass [GeV]",                       "bin":100,"xmin":0 ,"xmax":10},
+    "AllGenALP_e":                     {"name":"AllGenALP_e",                    "title":"All gen ALP energy [GeV]",                     "bin":100,"xmin":0 ,"xmax":100},
+    "AllGenALP_p":                     {"name":"AllGenALP_p",                    "title":"All gen ALP p [GeV]",                          "bin":100,"xmin":0 ,"xmax":50},
+    "AllGenALP_pt":                    {"name":"AllGenALP_pt",                   "title":"All gen ALP p_{T} [GeV]",                      "bin":100,"xmin":0 ,"xmax":50},
+    "AllGenALP_pz":                    {"name":"AllGenALP_pz",                   "title":"All gen ALP p_{z} [GeV]",                      "bin":100,"xmin":0 ,"xmax":50},
+    "AllGenALP_eta":                   {"name":"AllGenALP_eta",                  "title":"All gen ALP #eta",                             "bin":60, "xmin":-3,"xmax":3},
+    "AllGenALP_theta":                 {"name":"AllGenALP_theta",                "title":"All gen ALP #theta",                           "bin":64, "xmin":0,"xmax":3.2},
+    "AllGenALP_phi":                   {"name":"AllGenALP_phi",                  "title":"All gen ALP #phi",                             "bin":64, "xmin":-3.2,"xmax":3.2},
+
+    "n_FSGenElectron":                 {"name":"n_FSGenElectron",                "title":"Number of final state gen electrons",        "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    "n_FSGenPositron":                 {"name":"n_FSGenPositron",                "title":"Number of final state gen positrons",        "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    "n_FSGenNeutrino":                 {"name":"n_FSGenNeutrino",                "title":"Number of final state gen neutrinos",        "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    "n_FSGenAntiNeutrino":             {"name":"n_FSGenAntiNeutrino",            "title":"Number of final state gen anti-neutrinos",   "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    "n_FSGenPhoton":                   {"name":"n_FSGenPhoton",                  "title":"Number of final state gen photons",          "bin":8,"xmin":-0.5 ,"xmax":7.5},
+
+    # "n_FSGenElectron_forFS2GenPhotons":                 {"name":"n_FSGenElectron_forFS2GenPhotons",                "title":"Number of final state gen electrons for events with 2 FS photons",        "bin":7,"xmin":-2.5 ,"xmax":4.5},
+    # "n_FSGenPositron_forFS2GenPhotons":                 {"name":"n_FSGenPositron_forFS2GenPhotons",                "title":"Number of final state gen positrons for events with 2 FS photons",        "bin":7,"xmin":-2.5 ,"xmax":4.5},
+
+    "FSGenElectron_e":                 {"name":"FSGenElectron_e",                "title":"Final state gen electrons energy [GeV]",     "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenElectron_p":                 {"name":"FSGenElectron_p",                "title":"Final state gen electrons p [GeV]",          "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenElectron_pt":                {"name":"FSGenElectron_pt",               "title":"Final state gen electrons p_{T} [GeV]",      "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenElectron_pz":                {"name":"FSGenElectron_pz",               "title":"Final state gen electrons p_{z} [GeV]",      "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenElectron_eta":               {"name":"FSGenElectron_eta",              "title":"Final state gen electrons #eta",             "bin":60, "xmin":-3,"xmax":3},
+    "FSGenElectron_theta":             {"name":"FSGenElectron_theta",            "title":"Final state gen electrons #theta",           "bin":64, "xmin":0,"xmax":3.2},
+    "FSGenElectron_phi":               {"name":"FSGenElectron_phi",              "title":"Final state gen electrons #phi",             "bin":64, "xmin":-3.2,"xmax":3.2},
+
+    "FSGenPositron_e":                 {"name":"FSGenPositron_e",                "title":"Final state gen positrons energy [GeV]",     "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenPositron_p":                 {"name":"FSGenPositron_p",                "title":"Final state gen positrons p [GeV]",          "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenPositron_pt":                {"name":"FSGenPositron_pt",               "title":"Final state gen positrons p_{T} [GeV]",      "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenPositron_pz":                {"name":"FSGenPositron_pz",               "title":"Final state gen positrons p_{z} [GeV]",      "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenPositron_eta":               {"name":"FSGenPositron_eta",              "title":"Final state gen positrons #eta",             "bin":60, "xmin":-3,"xmax":3},
+    "FSGenPositron_theta":             {"name":"FSGenPositron_theta",            "title":"Final state gen positrons #theta",           "bin":64, "xmin":0,"xmax":3.2},
+    "FSGenPositron_phi":               {"name":"FSGenPositron_phi",              "title":"Final state gen positrons #phi",             "bin":64, "xmin":-3.2,"xmax":3.2},
+
+    "FSGenNeutrino_e":                 {"name":"FSGenNeutrino_e",                "title":"Final state gen neutrino energy [GeV]",      "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenNeutrino_p":                 {"name":"FSGenNeutrino_p",                "title":"Final state gen neutrino p [GeV]",           "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenNeutrino_pt":                {"name":"FSGenNeutrino_pt",               "title":"Final state gen neutrino p_{T} [GeV]",       "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenNeutrino_pz":                {"name":"FSGenNeutrino_pz",               "title":"Final state gen neutrino p_{z} [GeV]",       "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenNeutrino_eta":               {"name":"FSGenNeutrino_eta",              "title":"Final state gen neutrinos #eta",             "bin":60, "xmin":-3,"xmax":3},
+    "FSGenNeutrino_theta":             {"name":"FSGenNeutrino_theta",            "title":"Final state gen neutrinos #theta",           "bin":64, "xmin":0,"xmax":3.2},
+    "FSGenNeutrino_phi":               {"name":"FSGenNeutrino_phi",              "title":"Final state gen neutrinos #phi",             "bin":64, "xmin":-3.2,"xmax":3.2},
+
+    "FSGenAntiNeutrino_e":             {"name":"FSGenAntiNeutrino_e",            "title":"Final state gen anti-neutrino energy [GeV]", "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenAntiNeutrino_p":             {"name":"FSGenAntiNeutrino_p",            "title":"Final state gen anti-neutrino p [GeV]",      "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenAntiNeutrino_pt":            {"name":"FSGenAntiNeutrino_pt",           "title":"Final state gen anti-neutrino p_{T} [GeV]",  "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenAntiNeutrino_pz":            {"name":"FSGenAntiNeutrino_pz",           "title":"Final state gen anti-neutrino p_{z} [GeV]",  "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenAntiNeutrino_eta":           {"name":"FSGenAntiNeutrino_eta",          "title":"Final state gen anti-neutrinos #eta",        "bin":60, "xmin":-3,"xmax":3},
+    "FSGenAntiNeutrino_theta":         {"name":"FSGenAntiNeutrino_theta",        "title":"Final state gen anti-neutrinos #theta",      "bin":64, "xmin":0,"xmax":3.2},
+    "FSGenAntiNeutrino_phi":           {"name":"FSGenAntiNeutrino_phi",          "title":"Final state gen anti-neutrinos #phi",        "bin":64, "xmin":-3.2,"xmax":3.2},
+
+    "FSGenPhoton_e":                   {"name":"FSGenPhoton_e",                  "title":"Final state gen photons energy [GeV]",       "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenPhoton_p":                   {"name":"FSGenPhoton_p",                  "title":"Final state gen photons p [GeV]",            "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenPhoton_pt":                  {"name":"FSGenPhoton_pt",                 "title":"Final state gen photons p_{T} [GeV]",        "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenPhoton_pz":                  {"name":"FSGenPhoton_pz",                 "title":"Final state gen photons p_{z} [GeV]",        "bin":100,"xmin":0 ,"xmax":50},
+    "FSGenPhoton_eta":                 {"name":"FSGenPhoton_eta",                "title":"Final state gen photons #eta",               "bin":60, "xmin":-3,"xmax":3},
+    "FSGenPhoton_theta":               {"name":"FSGenPhoton_theta",              "title":"Final state gen photons #theta",             "bin":64, "xmin":0,"xmax":3.2},
+    "FSGenPhoton_phi":                 {"name":"FSGenPhoton_phi",                "title":"Final state gen photons #phi",               "bin":64, "xmin":-3.2,"xmax":3.2},
+
+    # "FSGenPhoton0_e":                 {"name":"FSGenPhoton0_e",                "title":"Final state gen photon_{0} energy [GeV]",               "bin":64, "xmin":-3.2,"xmax":3.2},
+    # "FSGenPhoton1_e":                 {"name":"FSGenPhoton1_e",                "title":"Final state gen photon_{1} energy [GeV]",               "bin":64, "xmin":-3.2,"xmax":3.2},
+    # "FSGenPhoton2_e":                 {"name":"FSGenPhoton2_e",                "title":"Final state gen photon_{2} energy [GeV]",               "bin":64, "xmin":-3.2,"xmax":3.2},
+    # "FSGenPhoton0_p":                   {"name":"FSGenPhoton0_p",                  "title":"Final state gen photon_{0} p [GeV]",            "bin":100,"xmin":0 ,"xmax":50},
+    # "FSGenPhoton1_p":                   {"name":"FSGenPhoton1_p",                  "title":"Final state gen photon_{1} p [GeV]",            "bin":100,"xmin":0 ,"xmax":50},
+    # "FSGenPhoton2_p":                   {"name":"FSGenPhoton2_p",                  "title":"Final state gen photon_{2} p [GeV]",            "bin":100,"xmin":0 ,"xmax":50},
+    # "FSGenPhoton0_pt":                  {"name":"FSGenPhoton0_pt",                 "title":"Final state gen photon_{0} p_{T} [GeV]",        "bin":100,"xmin":0 ,"xmax":50},
+    # "FSGenPhoton1_pt":                  {"name":"FSGenPhoton1_pt",                 "title":"Final state gen photon_{1} p_{T} [GeV]",        "bin":100,"xmin":0 ,"xmax":50},
+    # "FSGenPhoton2_pt":                  {"name":"FSGenPhoton2_pt",                 "title":"Final state gen photon_{2} p_{T} [GeV]",        "bin":100,"xmin":0 ,"xmax":50},
+
+    "FSGenPhoton_vertex_x": {"name":"FSGenPhoton_vertex_x", "title":"Final state gen photon production vertex x [mm]",      "bin":100,"xmin":-1000 ,"xmax":1000},
+    "FSGenPhoton_vertex_y": {"name":"FSGenPhoton_vertex_y", "title":"Final state gen photon production vertex y [mm]",      "bin":100,"xmin":-1000 ,"xmax":1000},
+    "FSGenPhoton_vertex_z": {"name":"FSGenPhoton_vertex_z", "title":"Final state gen photon production vertex z [mm]",      "bin":100,"xmin":-1000 ,"xmax":1000},
+
+    "FSGen_lifetime_xy": {"name":"FSGen_lifetime_xy", "title":"Gen ALP (FS eles) #tau_{xy} [s]",        "bin":100,"xmin":0 ,"xmax":1E-10},
+    "FSGen_lifetime_xyz": {"name":"FSGen_lifetime_xyz", "title":"Gen ALP (FS eles) #tau_{xyz} [s]",        "bin":100,"xmin":0 ,"xmax":1E-10},
+    "FSGen_Lxy":      {"name":"FSGen_Lxy",      "title":"Gen ALP (FS eles) L_{xy} [mm]",     "bin":100,"xmin":0 ,"xmax":1000},
+    "FSGen_Lxyz":     {"name":"FSGen_Lxyz",     "title":"Gen ALP (FS eles) L_{xyz} [mm]",    "bin":100,"xmin":0 ,"xmax":1000},
+
+    # "FSGen_a0a1_invMass":   {"name":"FSGen_a0a1_invMass",   "title":"Gen FS photons m_{01} [GeV]",           "bin":105,"xmin":-5, "xmax":100},
+    # "FSGen_a0a2_invMass":   {"name":"FSGen_a0a2_invMass",   "title":"Gen FS photons m_{02} [GeV]",           "bin":105,"xmin":-5, "xmax":100},
+    # "FSGen_a1a2_invMass":   {"name":"FSGen_a1a2_invMass",   "title":"Gen FS photons m_{12} [GeV]",           "bin":105,"xmin":-5, "xmax":100},
+    # "FSGen_aaa_invMass":   {"name":"FSGen_aaa_invMass",   "title":"Gen FS m_{#gamma #gamma #gamma} [GeV]",           "bin":105,"xmin":-5, "xmax":100},
+
+    "GenALP_mass":     {"name":"GenALP_mass",     "title":"Gen ALP mass [GeV]",      "bin":100,"xmin":0 ,"xmax":10},
+    "GenALP_p":        {"name":"GenALP_p",        "title":"Gen ALP p [GeV]",         "bin":100,"xmin":0 ,"xmax":50},
+    "GenALP_pt":       {"name":"GenALP_pt",       "title":"Gen ALP p_{T} [GeV]",     "bin":100,"xmin":0 ,"xmax":50},
+    "GenALP_pz":       {"name":"GenALP_pz",       "title":"Gen ALP p_{z} [GeV]",     "bin":100,"xmin":0 ,"xmax":50},
+    "GenALP_eta":      {"name":"GenALP_eta",      "title":"Gen ALP #eta",            "bin":60, "xmin":-3,"xmax":3},
+    "GenALP_theta":    {"name":"GenALP_theta",    "title":"Gen ALP #theta",          "bin":64, "xmin":0,"xmax":3.2},
+    "GenALP_phi":      {"name":"GenALP_phi",      "title":"Gen ALP #phi",            "bin":64, "xmin":-3.2,"xmax":3.2},
+    "GenALP_lifetime_xy": {"name":"GenALP_lifetime_xy", "title":"Gen ALP #tau_{xy} [s]",        "bin":100,"xmin":0 ,"xmax":1E-10},
+    "GenALP_lifetime_xyz": {"name":"GenALP_lifetime_xyz", "title":"Gen ALP #tau_{xyz} [s]",        "bin":100,"xmin":0 ,"xmax":1E-10},
+    "GenALP_Lxy":      {"name":"GenALP_Lxy",      "title":"Gen ALP L_{xy} [mm]",     "bin":100,"xmin":0 ,"xmax":1000},
+    "GenALP_Lxyz":     {"name":"GenALP_Lxyz",     "title":"Gen ALP L_{xyz} [mm]",    "bin":100,"xmin":0 ,"xmax":1000},
+    "GenALP_vertex_x": {"name":"GenALP_vertex_x", "title":"Gen ALP production vertex x [mm]",   "bin":100,"xmin":-1000 ,"xmax":1000},
+    "GenALP_vertex_y": {"name":"GenALP_vertex_y", "title":"Gen ALP production vertex y [mm]",   "bin":100,"xmin":-1000 ,"xmax":1000},
+    "GenALP_vertex_z": {"name":"GenALP_vertex_z", "title":"Gen ALP production vertex z [mm]",   "bin":100,"xmin":-1000 ,"xmax":1000},
+
+    "GenALPPhoton1_e":        {"name":"GenALPPhoton1_e",        "title":"Gen photon_{1} energy [GeV]",                  "bin":100,"xmin":0 ,"xmax":50},
+    "GenALPPhoton2_e":        {"name":"GenALPPhoton2_e",        "title":"Gen photon_{2} energy [GeV]",                                "bin":100,"xmin":0 ,"xmax":50},
+    "GenALPPhoton1_p":        {"name":"GenALPPhoton1_p",        "title":"Gen photon_{1} p [GeV]",                       "bin":100,"xmin":0 ,"xmax":50},
+    "GenALPPhoton2_p":        {"name":"GenALPPhoton2_p",        "title":"Gen photon_{2} p [GeV]",                                     "bin":100,"xmin":0 ,"xmax":50},
+    "GenALPPhoton1_pt":       {"name":"GenALPPhoton1_pt",       "title":"Gen photon_{1} p_{T} [GeV]",                   "bin":100,"xmin":0 ,"xmax":50},
+    "GenALPPhoton2_pt":       {"name":"GenALPPhoton2_pt",       "title":"Gen photon_{2} p_{T} [GeV]",                                 "bin":100,"xmin":0 ,"xmax":50},
+    "GenALPPhoton1_pz":       {"name":"GenALPPhoton1_pz",       "title":"Gen photon_{1} p_{z} [GeV]",                   "bin":100,"xmin":0 ,"xmax":50},
+    "GenALPPhoton2_pz":       {"name":"GenALPPhoton2_pz",       "title":"Gen photon_{2} p_{z} [GeV]",                                 "bin":100,"xmin":0 ,"xmax":50},
+    "GenALPPhoton1_eta":      {"name":"GenALPPhoton1_eta",      "title":"Gen photon_{1} #eta",                          "bin":60, "xmin":-3,"xmax":3},
+    "GenALPPhoton2_eta":      {"name":"GenALPPhoton2_eta",      "title":"Gen photon_{2} #eta",                                        "bin":60, "xmin":-3,"xmax":3},
+    "GenALPPhoton1_theta":    {"name":"GenALPPhoton1_theta",    "title":"Gen photon_{1} #theta",                        "bin":64, "xmin":0,"xmax":3.2},
+    "GenALPPhoton2_theta":    {"name":"GenALPPhoton2_theta",    "title":"Gen photon_{2} #theta",                                      "bin":64, "xmin":0,"xmax":3.2},
+    "GenALPPhoton1_phi":      {"name":"GenALPPhoton1_phi",      "title":"Gen photon_{1} #phi",                          "bin":64, "xmin":-3.2,"xmax":3.2},
+    "GenALPPhoton2_phi":      {"name":"GenALPPhoton2_phi",      "title":"Gen photon_{2} #phi",                                        "bin":64, "xmin":-3.2,"xmax":3.2},
+
+    "GenALPPhoton1_vertex_x": {"name":"GenALPPhoton1_vertex_x", "title":"Gen photon_{1} production vertex x [mm]",      "bin":100,"xmin":-1000 ,"xmax":1000},
+    "GenALPPhoton1_vertex_y": {"name":"GenALPPhoton1_vertex_y", "title":"Gen photon_{1} production vertex y [mm]",      "bin":100,"xmin":-1000 ,"xmax":1000},
+    "GenALPPhoton1_vertex_z": {"name":"GenALPPhoton1_vertex_z", "title":"Gen photon_{1} production vertex z [mm]",      "bin":100,"xmin":-1000 ,"xmax":1000},
+
+    "GenALP_aa_invMass":   {"name":"GenALP_aa_invMass",   "title":"Gen m_{#gamma #gamma} (from ALP) [GeV]",           "bin":100,"xmin":0, "xmax":10},
+
+    #reco variables
+    "n_RecoTracks":                    {"name":"n_RecoTracks",                   "title":"Total number of reco tracks",           "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    "n_RecoALPTracks":                 {"name":"n_RecoALPTracks",                "title":"Number of reco ALP tracks",             "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    "RecoALP_DecayVertex_x":           {"name":"RecoALPDecayVertex.position.x",  "title":"Reco ALP decay vertex x [mm]",            "bin":100,"xmin":-1000 ,"xmax":1000},
+    "RecoALP_DecayVertex_y":           {"name":"RecoALPDecayVertex.position.y",  "title":"Reco ALP decay vertex y [mm]",            "bin":100,"xmin":-1000 ,"xmax":1000},
+    "RecoALP_DecayVertex_z":           {"name":"RecoALPDecayVertex.position.z",  "title":"Reco ALP decay vertex z [mm]",            "bin":100,"xmin":-1000 ,"xmax":1000},
+    "RecoALP_DecayVertex_chi2":        {"name":"RecoALPDecayVertex.chi2",        "title":"Reco ALP decay vertex #chi^{2}",          "bin":100,"xmin":0 ,"xmax":3},
+    "RecoALP_DecayVertex_probability": {"name":"RecoALPDecayVertex.probability", "title":"Reco ALP decay vertex probability",       "bin":100,"xmin":0 ,"xmax":10},
+
+    "RecoALPPhoton1_e":        {"name":"RecoALPPhoton1_e",        "title":"Reco photon_{1} (from ALP) energy [GeV]", "bin":100,"xmin":0 ,"xmax":50},
+    "RecoALPPhoton2_e":        {"name":"RecoALPPhoton2_e",        "title":"Reco photon_{2} (from ALP) energy [GeV]",               "bin":100,"xmin":0 ,"xmax":50},
+    "RecoALPPhoton1_p":        {"name":"RecoALPPhoton1_p",        "title":"Reco photon_{1} (from ALP) p [GeV]",      "bin":100,"xmin":0 ,"xmax":50},
+    "RecoALPPhoton2_p":        {"name":"RecoALPPhoton2_p",        "title":"Reco photon_{2} (from ALP) p [GeV]",                    "bin":100,"xmin":0 ,"xmax":50},
+    "RecoALPPhoton1_pt":       {"name":"RecoALPPhoton1_pt",       "title":"Reco photon_{1} (from ALP) p_{T} [GeV]",  "bin":100,"xmin":0 ,"xmax":50},
+    "RecoALPPhoton2_pt":       {"name":"RecoALPPhoton2_pt",       "title":"Reco photon_{2} (from ALP) p_{T} [GeV]",                "bin":100,"xmin":0 ,"xmax":50},
+    "RecoALPPhoton1_pz":       {"name":"RecoALPPhoton1_pz",       "title":"Reco photon_{1} (from ALP) p_{z} [GeV]",  "bin":100,"xmin":0 ,"xmax":50},
+    "RecoALPPhoton2_pz":       {"name":"RecoALPPhoton2_pz",       "title":"Reco photon_{2} (from ALP) p_{z} [GeV]",                "bin":100,"xmin":0 ,"xmax":50},
+    "RecoALPPhoton1_eta":      {"name":"RecoALPPhoton1_eta",      "title":"Reco photon_{1} (from ALP) #eta",         "bin":60, "xmin":-3,"xmax":3},
+    "RecoALPPhoton2_eta":      {"name":"RecoALPPhoton2_eta",      "title":"Reco photon_{2} (from ALP) #eta",                       "bin":60, "xmin":-3,"xmax":3},
+    "RecoALPPhoton1_theta":    {"name":"RecoALPPhoton1_theta",    "title":"Reco photon_{1} (from ALP) #theta",       "bin":64, "xmin":0,"xmax":3.2},
+    "RecoALPPhoton2_theta":    {"name":"RecoALPPhoton2_theta",    "title":"Reco photon_{2} (from ALP) #theta",                     "bin":64, "xmin":0,"xmax":3.2},
+    "RecoALPPhoton1_phi":      {"name":"RecoALPPhoton1_phi",      "title":"Reco photon_{1} (from ALP) #phi",         "bin":64, "xmin":-3.2,"xmax":3.2},
+    "RecoALPPhoton2_phi":      {"name":"RecoALPPhoton2_phi",      "title":"Reco photon_{2} (from ALP) #phi",                       "bin":64, "xmin":-3.2,"xmax":3.2},
+    "RecoALPPhoton1_charge":   {"name":"RecoALPPhoton1_charge",   "title":"Reco photon_{1} (from ALP) charge",       "bin":3, "xmin":-1.5,"xmax":1.5},
+    "RecoALPPhoton2_charge":   {"name":"RecoALPPhoton2_charge",   "title":"Reco photon_{2} (from ALP) charge",                     "bin":3, "xmin":-1.5,"xmax":1.5},
+
+    "RecoALP_aa_invMass":   {"name":"RecoALP_aa_invMass",   "title":"Reco m_{#gamma #gamma} (from ALP) [GeV]",           "bin":100,"xmin":0, "xmax":100},
+
+    "n_RecoJets":       {"name":"n_RecoJets",      "title":"Total number of reco jets",         "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    "n_RecoPhotons":    {"name":"n_RecoPhotons",   "title":"Total number of reco photons",      "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    "n_RecoElectrons":  {"name":"n_RecoElectrons", "title":"Total number of reco electrons",    "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    "n_RecoMuons":      {"name":"n_RecoMuons",     "title":"Total number of reco muons",        "bin":5,"xmin":-0.5 ,"xmax":4.5},
+
+    "RecoJet_e":        {"name":"RecoJet_e",        "title":"Reco jet energy [GeV]", "bin":100,"xmin":0 ,"xmax":50},
+    "RecoJet_p":        {"name":"RecoJet_p",        "title":"Reco jet p [GeV]",      "bin":100,"xmin":0 ,"xmax":50},
+    "RecoJet_pt":       {"name":"RecoJet_pt",       "title":"Reco jet p_{T} [GeV]",  "bin":100,"xmin":0 ,"xmax":50},
+    "RecoJet_pz":       {"name":"RecoJet_pz",       "title":"Reco jet p_{z} [GeV]",  "bin":100,"xmin":0 ,"xmax":50},
+    "RecoJet_eta":      {"name":"RecoJet_eta",      "title":"Reco jet #eta",         "bin":60, "xmin":-3,"xmax":3},
+    "RecoJet_theta":    {"name":"RecoJet_theta",    "title":"Reco jet #theta",       "bin":64, "xmin":0,"xmax":3.2},
+    "RecoJet_phi":      {"name":"RecoJet_phi",      "title":"Reco jet #phi",         "bin":64, "xmin":-3.2,"xmax":3.2},
+    "RecoJet_charge":   {"name":"RecoJet_charge",   "title":"Reco jet charge",       "bin":3, "xmin":-1.5,"xmax":1.5},
+
+    "RecoElectron_e":        {"name":"RecoElectron_e",        "title":"Reco electron energy [GeV]", "bin":100,"xmin":0 ,"xmax":50},
+    "RecoElectron_p":        {"name":"RecoElectron_p",        "title":"Reco electron p [GeV]",      "bin":100,"xmin":0 ,"xmax":50},
+    "RecoElectron_pt":       {"name":"RecoElectron_pt",       "title":"Reco electron p_{T} [GeV]",  "bin":100,"xmin":0 ,"xmax":50},
+    "RecoElectron_pz":       {"name":"RecoElectron_pz",       "title":"Reco electron p_{z} [GeV]",  "bin":100,"xmin":0 ,"xmax":50},
+    "RecoElectron_eta":      {"name":"RecoElectron_eta",      "title":"Reco electron #eta",         "bin":60, "xmin":-3,"xmax":3},
+    "RecoElectron_theta":    {"name":"RecoElectron_theta",    "title":"Reco electron #theta",       "bin":64, "xmin":0,"xmax":3.2},
+    "RecoElectron_phi":      {"name":"RecoElectron_phi",      "title":"Reco electron #phi",         "bin":64, "xmin":-3.2,"xmax":3.2},
+    "RecoElectron_charge":   {"name":"RecoElectron_charge",   "title":"Reco electron charge",       "bin":3, "xmin":-1.5,"xmax":1.5},
+
+    "RecoPhoton_e":        {"name":"RecoPhoton_e",        "title":"Reco photon energy [GeV]", "bin":100,"xmin":0 ,"xmax":50},
+    "RecoPhoton_p":        {"name":"RecoPhoton_p",        "title":"Reco photon p [GeV]",      "bin":100,"xmin":0 ,"xmax":50},
+    "RecoPhoton_pt":       {"name":"RecoPhoton_pt",       "title":"Reco photon p_{T} [GeV]",  "bin":100,"xmin":0 ,"xmax":50},
+    "RecoPhoton_pz":       {"name":"RecoPhoton_pz",       "title":"Reco photon p_{z} [GeV]",  "bin":100,"xmin":0 ,"xmax":50},
+    "RecoPhoton_eta":      {"name":"RecoPhoton_eta",      "title":"Reco photon #eta",         "bin":60, "xmin":-3,"xmax":3},
+    "RecoPhoton_theta":    {"name":"RecoPhoton_theta",    "title":"Reco photon #theta",       "bin":64, "xmin":0,"xmax":3.2},
+    "RecoPhoton_phi":      {"name":"RecoPhoton_phi",      "title":"Reco photon #phi",         "bin":64, "xmin":-3.2,"xmax":3.2},
+    "RecoPhoton_charge":   {"name":"RecoPhoton_charge",   "title":"Reco photon charge",       "bin":3, "xmin":-1.5,"xmax":1.5},
+
+    "RecoMuon_e":        {"name":"RecoMuon_e",        "title":"Reco muon energy [GeV]", "bin":100,"xmin":0 ,"xmax":50},
+    "RecoMuon_p":        {"name":"RecoMuon_p",        "title":"Reco muon p [GeV]",      "bin":100,"xmin":0 ,"xmax":50},
+    "RecoMuon_pt":       {"name":"RecoMuon_pt",       "title":"Reco muon p_{T} [GeV]",  "bin":100,"xmin":0 ,"xmax":50},
+    "RecoMuon_pz":       {"name":"RecoMuon_pz",       "title":"Reco muon p_{z} [GeV]",  "bin":100,"xmin":0 ,"xmax":50},
+    "RecoMuon_eta":      {"name":"RecoMuon_eta",      "title":"Reco muon #eta",         "bin":60, "xmin":-3,"xmax":3},
+    "RecoMuon_theta":    {"name":"RecoMuon_theta",    "title":"Reco muon #theta",       "bin":64, "xmin":0,"xmax":3.2},
+    "RecoMuon_phi":      {"name":"RecoMuon_phi",      "title":"Reco muon #phi",         "bin":64, "xmin":-3.2,"xmax":3.2},
+    "RecoMuon_charge":   {"name":"RecoMuon_charge",   "title":"Reco muon charge",       "bin":3, "xmin":-1.5,"xmax":1.5},
+
+    "RecoMissingEnergy_e":       {"name":"RecoMissingEnergy_e",       "title":"Reco Total Missing Energy [GeV]",    "bin":100,"xmin":0 ,"xmax":50},
+    "RecoMissingEnergy_p":       {"name":"RecoMissingEnergy_p",       "title":"Reco Total Missing p [GeV]",         "bin":100,"xmin":0 ,"xmax":50},
+    "RecoMissingEnergy_pt":      {"name":"RecoMissingEnergy_pt",      "title":"Reco Missing p_{T} [GeV]",           "bin":100,"xmin":0 ,"xmax":50},
+    "RecoMissingEnergy_px":      {"name":"RecoMissingEnergy_px",      "title":"Reco Missing p_{x} [GeV]",           "bin":100,"xmin":0 ,"xmax":50},
+    "RecoMissingEnergy_py":      {"name":"RecoMissingEnergy_py",      "title":"Reco Missing p_{y} [GeV]",           "bin":100,"xmin":0 ,"xmax":50},
+    "RecoMissingEnergy_pz":      {"name":"RecoMissingEnergy_pz",      "title":"Reco Missing p_{z} [GeV]",           "bin":100,"xmin":0 ,"xmax":50},
+    "RecoMissingEnergy_eta":     {"name":"RecoMissingEnergy_eta",     "title":"Reco Missing Energy #eta",           "bin":60,"xmin":-3 ,"xmax":3},
+    "RecoMissingEnergy_theta":   {"name":"RecoMissingEnergy_theta",   "title":"Reco Missing Energy #theta",         "bin":64,"xmin":0 , "xmax":3.2},
+    "RecoMissingEnergy_phi":     {"name":"RecoMissingEnergy_phi",     "title":"Reco Missing Energy #phi",           "bin":64,"xmin":-3.2 ,"xmax":3.2},
+
+    #gen-reco
+    "GenMinusRecoALPPhoton1_e":    {"name":"GenMinusRecoALPPhoton1_e",    "title":"Gen photon_{1} energy - Reco photon_{1} energy [GeV]","bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALPPhoton2_e":    {"name":"GenMinusRecoALPPhoton2_e",    "title":"Gen photon_{2} energy - Reco photon_{2} energy [GeV]",                            "bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALPPhoton1_p":    {"name":"GenMinusRecoALPPhoton1_p",    "title":"Gen photon_{1} p - Reco photon_{1} p [GeV]",          "bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALPPhoton2_p":    {"name":"GenMinusRecoALPPhoton2_p",    "title":"Gen photon_{2} p - Reco photon_{2} p [GeV]",                                      "bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALPPhoton1_pt":   {"name":"GenMinusRecoALPPhoton1_pt",   "title":"Gen photon_{1} p_{T} - Reco photon_{1} p_{T} [GeV]",  "bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALPPhoton2_pt":   {"name":"GenMinusRecoALPPhoton2_pt",   "title":"Gen photon_{2} p_{T} - Reco photon_{2} p_{T} [GeV]",                              "bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALPPhoton1_pz":   {"name":"GenMinusRecoALPPhoton1_pz",   "title":"Gen photon_{1} p_{z} - Reco photon_{1} p_{z} [GeV]",  "bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALPPhoton2_pz":   {"name":"GenMinusRecoALPPhoton2_pz",   "title":"Gen photon_{2} p_{z} - Reco photon_{2} p_{z} [GeV]",                              "bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALPPhoton1_eta":  {"name":"GenMinusRecoALPPhoton1_eta",  "title":"Gen photon_{1} #eta - Reco photon_{1} #eta",          "bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALPPhoton2_eta":  {"name":"GenMinusRecoALPPhoton2_eta",  "title":"Gen photon_{2} #eta - Reco photon_{2} #eta",                                      "bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALPPhoton1_theta":{"name":"GenMinusRecoALPPhoton1_theta","title":"Gen photon_{1} #theta - Reco photon_{1} #theta",      "bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALPPhoton2_theta":{"name":"GenMinusRecoALPPhoton2_theta","title":"Gen photon_{2} #theta - Reco photon_{2} #theta",                                  "bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALPPhoton1_phi":  {"name":"GenMinusRecoALPPhoton1_phi",  "title":"Gen photon_{1} #phi - Reco photon_{1} #phi",          "bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALPPhoton2_phi":  {"name":"GenMinusRecoALPPhoton2_phi",  "title":"Gen photon_{2} #phi - Reco photon_{2} #phi",                                      "bin":100,"xmin":-5 ,"xmax":5},
+
+    "GenMinusRecoALP_DecayVertex_x":  {"name":"GenMinusRecoALP_DecayVertex_x",  "title":"Gen ALP decay vertex x - Reco ALP decay vertex x [mm]",              "bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALP_DecayVertex_y":  {"name":"GenMinusRecoALP_DecayVertex_y",  "title":"Gen ALP decay vertex y - Reco ALP decay vertex y [mm]",              "bin":100,"xmin":-5 ,"xmax":5},
+    "GenMinusRecoALP_DecayVertex_z":  {"name":"GenMinusRecoALP_DecayVertex_z",  "title":"Gen ALP decay vertex z - Reco ALP decay vertex z [mm]",              "bin":100,"xmin":-5 ,"xmax":5},
+
+}

--- a/examples/FCCee/bsm/LLPs/ALPs/analysis_plots.py
+++ b/examples/FCCee/bsm/LLPs/ALPs/analysis_plots.py
@@ -1,0 +1,246 @@
+import ROOT
+
+# global parameters
+intLumi        = 150.0e+06 #in pb-1
+
+###If scaleSig=0 or scaleBack=0, we don't apply any additional scaling, on top of the normalization to cross section and integrated luminosity, as defined in finalSel.py
+###If scaleSig or scaleBack is not defined, plots will be normalized to 1
+#scaleSig       = 0.
+#scaleBack      = 0.
+ana_tex        = 'e^{+}e^{-} #rightarrow Z #rightarrow #gamma ALP #rightarrow 3#gamma'
+#ana_tex        = ''
+#delphesVersion = '3.4.2'
+delphesVersion = ''
+energy         = 91
+collider       = 'FCC-ee'
+inputDir       = '/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/ALPs_3photons/winter2023/output_finalSel/'
+#formats        = ['png','pdf']
+formats        = ['pdf']
+yaxis          = ['lin','log']
+stacksig       = ['nostack']
+outdir         = 'plots/'
+splitLeg       = True
+
+variables = [
+    #gen variables
+    "All_n_GenALP",
+    "AllGenALP_mass",
+    "AllGenALP_e",
+    "AllGenALP_p",
+    "AllGenALP_pt",
+    "AllGenALP_pz",
+    "AllGenALP_eta",
+    "AllGenALP_theta",
+    "AllGenALP_phi",
+
+    "n_FSGenElectron",
+    "n_FSGenPositron",
+    "n_FSGenNeutrino",
+    "n_FSGenAntiNeutrino",
+    "n_FSGenPhoton",
+    # "n_FSGenElectron_forFS2GenPhotons",
+    # "n_FSGenPositron_forFS2GenPhotons",
+
+    "FSGenElectron_e",
+    "FSGenElectron_p",
+    "FSGenElectron_pt",
+    "FSGenElectron_pz",
+    "FSGenElectron_eta",
+    "FSGenElectron_theta",
+    "FSGenElectron_phi",
+
+    "FSGenPositron_e",
+    "FSGenPositron_p",
+    "FSGenPositron_pt",
+    "FSGenPositron_pz",
+    "FSGenPositron_eta",
+    "FSGenPositron_theta",
+    "FSGenPositron_phi",
+
+    "FSGenNeutrino_e",
+    "FSGenNeutrino_p",
+    "FSGenNeutrino_pt",
+    "FSGenNeutrino_pz",
+    "FSGenNeutrino_eta",
+    "FSGenNeutrino_theta",
+    "FSGenNeutrino_phi",
+
+    "FSGenAntiNeutrino_e",
+    "FSGenAntiNeutrino_p",
+    "FSGenAntiNeutrino_pt",
+    "FSGenAntiNeutrino_pz",
+    "FSGenAntiNeutrino_eta",
+    "FSGenAntiNeutrino_theta",
+    "FSGenAntiNeutrino_phi",
+
+    "FSGenPhoton_e",
+    "FSGenPhoton_p",
+    "FSGenPhoton_pt",
+    "FSGenPhoton_pz",
+    "FSGenPhoton_eta",
+    "FSGenPhoton_theta",
+    "FSGenPhoton_phi",
+
+    "FSGenPhoton_vertex_x",
+    "FSGenPhoton_vertex_y",
+    "FSGenPhoton_vertex_z",
+
+    "FSGen_Lxy",
+    "FSGen_Lxyz",
+    "FSGen_lifetime_xy",
+    "FSGen_lifetime_xyz",
+
+    # "FSGenPhoton0_e",
+    # "FSGenPhoton1_e",
+    # "FSGenPhoton2_e",
+    # "FSGenPhoton0_p",
+    # "FSGenPhoton1_p",
+    # "FSGenPhoton2_p",
+    # "FSGenPhoton0_pt",
+    # "FSGenPhoton1_pt",
+    # "FSGenPhoton2_pt",
+    # "FSGen_a0a1_invMass",
+    # "FSGen_a0a2_invMass",
+    # "FSGen_a1a2_invMass",
+    # "FSGen_aaa_invMass",
+
+    "GenALP_mass",
+    "GenALP_p",
+    "GenALP_pt",
+    "GenALP_pz",
+    "GenALP_eta",
+    "GenALP_theta",
+    "GenALP_phi",
+    "GenALP_lifetime_xy",
+    "GenALP_lifetime_xyz",
+    "GenALP_Lxy",
+    "GenALP_Lxyz",
+    "GenALP_vertex_x",
+    "GenALP_vertex_y",
+    "GenALP_vertex_z",
+
+    "GenALPPhoton1_e",
+    "GenALPPhoton2_e",
+    "GenALPPhoton1_p",
+    "GenALPPhoton2_p",
+    "GenALPPhoton1_pt",
+    "GenALPPhoton2_pt",
+    "GenALPPhoton1_pz",
+    "GenALPPhoton2_pz",
+    "GenALPPhoton1_eta",
+    "GenALPPhoton2_eta",
+    "GenALPPhoton1_theta",
+    "GenALPPhoton2_theta",
+    "GenALPPhoton1_phi",
+    "GenALPPhoton2_phi",
+    "GenALPPhoton1_vertex_x",
+    "GenALPPhoton1_vertex_y",
+    "GenALPPhoton1_vertex_z",
+
+    "GenALP_aa_invMass",
+
+    #reco variables
+    "n_RecoTracks",
+    "n_RecoALPTracks",
+    "RecoALP_DecayVertex_x",
+    "RecoALP_DecayVertex_y",
+    "RecoALP_DecayVertex_z",
+    "RecoALP_DecayVertex_chi2",
+    "RecoALP_DecayVertex_probability",
+
+    "RecoALPPhoton1_e",
+    "RecoALPPhoton2_e",
+    "RecoALPPhoton1_p",
+    "RecoALPPhoton2_p",
+    "RecoALPPhoton1_pt",
+    "RecoALPPhoton2_pt",
+    "RecoALPPhoton1_pz",
+    "RecoALPPhoton2_pz",
+    "RecoALPPhoton1_eta",
+    "RecoALPPhoton2_eta",
+    "RecoALPPhoton1_theta",
+    "RecoALPPhoton2_theta",
+    "RecoALPPhoton1_phi",
+    "RecoALPPhoton2_phi",
+    "RecoALPPhoton1_charge",
+    "RecoALPPhoton2_charge",
+
+    "n_RecoJets",
+    "n_RecoPhotons",
+    "n_RecoElectrons",
+    "n_RecoMuons",
+
+    "RecoJet_e",
+    "RecoJet_p",
+    "RecoJet_pt",
+    "RecoJet_pz",
+    "RecoJet_eta",
+    "RecoJet_theta",
+    "RecoJet_phi",
+    "RecoJet_charge",
+
+    "RecoElectron_e",
+    "RecoElectron_p",
+    "RecoElectron_pt",
+    "RecoElectron_pz",
+    "RecoElectron_eta",
+    "RecoElectron_theta",
+    "RecoElectron_phi",
+    "RecoElectron_charge",
+
+    "RecoPhoton_e",
+    "RecoPhoton_p",
+    "RecoPhoton_pt",
+    "RecoPhoton_pz",
+    "RecoPhoton_eta",
+    "RecoPhoton_theta",
+    "RecoPhoton_phi",
+    "RecoPhoton_charge",
+
+    "RecoMuon_e",
+    "RecoMuon_p",
+    "RecoMuon_pt",
+    "RecoMuon_pz",
+    "RecoMuon_eta",
+    "RecoMuon_theta",
+    "RecoMuon_phi",
+    "RecoMuon_charge",
+
+    "RecoMissingEnergy_e",
+    "RecoMissingEnergy_p",
+    "RecoMissingEnergy_pt",
+    "RecoMissingEnergy_px",
+    "RecoMissingEnergy_py",
+    "RecoMissingEnergy_pz",
+    "RecoMissingEnergy_eta",
+    "RecoMissingEnergy_theta",
+    "RecoMissingEnergy_phi",
+    
+]
+
+    
+###Dictionary with the analysis name as a key, and the list of selections to be plotted for this analysis. The name of the selections should be the same than in the final selection
+selections = {}
+selections['ALP']   = ["selNone"]#,"sel0","sel1"]
+
+extralabel = {}
+extralabel['selNone'] = "Before selection"
+#extralabel['sel0'] = "Selection: At least 1 ALP"
+#extralabel['sel1'] = "Selection: At least 1 ALP, at least 2 reco electrons"
+
+colors = {}
+colors['ALP_Z_aa_1GeV_cYY_0p5'] = ROOT.kRed
+#colors['Zee'] = ROOT.kGray+2
+
+plots = {}
+plots['ALP'] = {'signal':{
+    'ALP_Z_aa_1GeV_cYY_0p5':['ALP_Z_aa_1GeV_cYY_0p5'],
+},
+                'backgrounds':{},
+                #'Zee':['p8_ee_Zee_ecm91'],
+}
+
+
+legend = {}
+legend['ALP_Z_aa_1GeV_cYY_0p5'] = 'm_{ALP} = 1 GeV, c_{YY} = 0.5'
+#legend['Zee'] = 'e^{+}e^{-} #rightarrow Z #rightarrow ee'

--- a/examples/FCCee/bsm/LLPs/ALPs/analysis_stage1.py
+++ b/examples/FCCee/bsm/LLPs/ALPs/analysis_stage1.py
@@ -1,0 +1,704 @@
+#Mandatory: List of processes
+processList = {
+
+        #centrally-produced backgrounds
+        #'p8_ee_Zee_ecm91':{'chunks':100},
+
+        #privately-produced signals
+        'ALP_Z_aa_1GeV_cYY_0p5':{},
+
+        #test
+        #'p8_ee_Zee_ecm91':{'fraction':0.000001},
+}
+
+#Production tag. This points to the yaml files for getting sample statistics
+#Mandatory when running over EDM4Hep centrally produced events
+#Comment out when running over privately produced events
+#prodTag     = "FCCee/winter2023/IDEA/"
+
+#Input directory
+#Comment out when running over centrally produced events
+#Mandatory when running over privately produced events
+inputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/ALPs_3photons/winter2023/output_MadgraphPythiaDelphes"
+
+
+#Optional: output directory, default is local dir
+outputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/ALPs_3photons/winter2023/output_stage1/"
+#outputDir = "/eos/user/j/jalimena/FCCeeLLP/"
+#outputDir = "output_stage1/"
+
+#outputDirEos = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/ALPs_3photons/winter2023/output_stage1/"
+#outputDirEos = "/eos/user/j/jalimena/FCCeeLLP/"
+#eosType = "eosuser"
+
+#Optional: ncpus, default is 4
+nCPUS       = 4
+
+#Optional running on HTCondor, default is False
+runBatch    = False
+#runBatch    = True
+
+#Optional batch queue name when running on HTCondor, default is workday
+batchQueue = "longlunch"
+
+#Optional computing account when running on HTCondor, default is group_u_FCC.local_gen
+compGroup = "group_u_FCC.local_gen"
+
+#Mandatory: RDFanalysis class where the use defines the operations on the TTree
+class RDFanalysis():
+        def analysers(df):
+
+                df2 = (df
+
+                #Access the various objects and their properties with the following syntax: .Define("<your_variable>", "<accessor_fct (name_object)>")
+		#This will create a column in the RDataFrame named <your_variable> and filled with the return value of the <accessor_fct> for the given collection/object 
+		#Accessor functions are the functions found in the C++ analyzers code that return a certain variable, e.g. <namespace>::get_n(object) returns the number 
+		#of these objects in the event and <namespace>::get_pt(object) returns the pt of the object. Here you can pick between two namespaces to access either
+		#reconstructed (namespace = ReconstructedParticle) or MC-level objects (namespace = MCParticle). 
+		#For the name of the object, in principle the names of the EDM4HEP collections are used - photons, muons and electrons are an exception, see below
+
+		#OVERVIEW: Accessing different objects and counting them
+               
+              # Following code is written specifically for the ALP study
+                ####################################################################################################
+                .Alias("Particle1", "Particle#1.index")
+                .Alias("MCRecoAssociations0", "MCRecoAssociations#0.index")
+                .Alias("MCRecoAssociations1", "MCRecoAssociations#1.index")
+ 
+                ##### Added branch for MCParticle; finding PID of the MC particle for ALP
+                .Define("GenALP_PID", "MCParticle::sel_pdgID(9000005, false)(Particle)")
+                .Define("GenALP_decay", "MCParticle::get_list_of_particles_from_decay(0, GenALP_PID, Particle1)")
+
+                .Define("All_n_GenALP", "MCParticle::get_n(GenALP_PID)")
+                .Define("AllGenALP_mass", "MCParticle::get_mass(GenALP_PID)") #finding the generator mass of the ALP through separate ALP branch
+                .Define("AllGenALP_e", "MCParticle::get_e(GenALP_PID)")
+                .Define("AllGenALP_p", "MCParticle::get_p(GenALP_PID)")
+                .Define("AllGenALP_pt", "MCParticle::get_pt(GenALP_PID)")    #finding the pt of the ALP thorugh separate ALP branch
+                .Define("AllGenALP_px", "MCParticle::get_px(GenALP_PID)")
+                .Define("AllGenALP_py", "MCParticle::get_py(GenALP_PID)")
+                .Define("AllGenALP_pz", "MCParticle::get_pz(GenALP_PID)")
+                .Define("AllGenALP_eta", "MCParticle::get_eta(GenALP_PID)")
+                .Define("AllGenALP_theta", "MCParticle::get_theta(GenALP_PID)")
+                .Define("AllGenALP_phi", "MCParticle::get_phi(GenALP_PID)")
+                .Define("AllGenALP_genStatus", "MCParticle::get_genStatus(GenALP_PID)")
+
+                #all final state gen electrons
+                .Define("GenElectron_PID", "MCParticle::sel_pdgID(11, false)(Particle)") #get MCParticle electrons, but not their charge conjugates
+                .Define("FSGenElectron", "MCParticle::sel_genStatus(1)(GenElectron_PID)") #gen status==1 means final state particle (FS)
+                .Define("n_FSGenElectron", "MCParticle::get_n(FSGenElectron)")
+                .Define("FSGenElectron_e", "MCParticle::get_e(FSGenElectron)")
+                .Define("FSGenElectron_p", "MCParticle::get_p(FSGenElectron)")
+                .Define("FSGenElectron_pt", "MCParticle::get_pt(FSGenElectron)")
+                .Define("FSGenElectron_px", "MCParticle::get_px(FSGenElectron)")
+                .Define("FSGenElectron_py", "MCParticle::get_py(FSGenElectron)")
+                .Define("FSGenElectron_pz", "MCParticle::get_pz(FSGenElectron)")
+                .Define("FSGenElectron_eta", "MCParticle::get_eta(FSGenElectron)")
+                .Define("FSGenElectron_theta", "MCParticle::get_theta(FSGenElectron)")
+                .Define("FSGenElectron_phi", "MCParticle::get_phi(FSGenElectron)")
+
+                #all final state gen positrons
+                .Define("GenPositron_PID", "MCParticle::sel_pdgID(-11, false)(Particle)")
+                .Define("FSGenPositron", "MCParticle::sel_genStatus(1)(GenPositron_PID)") #gen status==1 means final state particle (FS)
+                .Define("n_FSGenPositron", "MCParticle::get_n(FSGenPositron)")
+                .Define("FSGenPositron_e", "MCParticle::get_e(FSGenPositron)")
+                .Define("FSGenPositron_p", "MCParticle::get_p(FSGenPositron)")
+                .Define("FSGenPositron_pt", "MCParticle::get_pt(FSGenPositron)")
+                .Define("FSGenPositron_px", "MCParticle::get_px(FSGenPositron)")
+                .Define("FSGenPositron_py", "MCParticle::get_py(FSGenPositron)")
+                .Define("FSGenPositron_pz", "MCParticle::get_pz(FSGenPositron)")
+                .Define("FSGenPositron_eta", "MCParticle::get_eta(FSGenPositron)")
+                .Define("FSGenPositron_theta", "MCParticle::get_theta(FSGenPositron)")
+                .Define("FSGenPositron_phi", "MCParticle::get_phi(FSGenPositron)")
+
+                #all final state gen neutrinos
+                .Define("GenNeutrino_PID", "MCParticle::sel_pdgID(12, false)(Particle)")
+                .Define("FSGenNeutrino", "MCParticle::sel_genStatus(1)(GenNeutrino_PID)") #gen status==1 means final state particle (FS)
+                .Define("n_FSGenNeutrino", "MCParticle::get_n(FSGenNeutrino)")
+                .Define("FSGenNeutrino_e", "MCParticle::get_e(FSGenNeutrino)")
+                .Define("FSGenNeutrino_p", "MCParticle::get_p(FSGenNeutrino)")
+                .Define("FSGenNeutrino_pt", "MCParticle::get_pt(FSGenNeutrino)")
+                .Define("FSGenNeutrino_px", "MCParticle::get_px(FSGenNeutrino)")
+                .Define("FSGenNeutrino_py", "MCParticle::get_py(FSGenNeutrino)")
+                .Define("FSGenNeutrino_pz", "MCParticle::get_pz(FSGenNeutrino)")
+                .Define("FSGenNeutrino_eta", "MCParticle::get_eta(FSGenNeutrino)")
+                .Define("FSGenNeutrino_theta", "MCParticle::get_theta(FSGenNeutrino)")
+                .Define("FSGenNeutrino_phi", "MCParticle::get_phi(FSGenNeutrino)")
+
+                #all final state gen anti-neutrinos
+                .Define("GenAntiNeutrino_PID", "MCParticle::sel_pdgID(-12, false)(Particle)")
+                .Define("FSGenAntiNeutrino", "MCParticle::sel_genStatus(1)(GenAntiNeutrino_PID)") #gen status==1 means final state particle (FS)
+                .Define("n_FSGenAntiNeutrino", "MCParticle::get_n(FSGenAntiNeutrino)")
+                .Define("FSGenAntiNeutrino_e", "MCParticle::get_e(FSGenAntiNeutrino)")
+                .Define("FSGenAntiNeutrino_p", "MCParticle::get_p(FSGenAntiNeutrino)")
+                .Define("FSGenAntiNeutrino_pt", "MCParticle::get_pt(FSGenAntiNeutrino)")
+                .Define("FSGenAntiNeutrino_px", "MCParticle::get_px(FSGenAntiNeutrino)")
+                .Define("FSGenAntiNeutrino_py", "MCParticle::get_py(FSGenAntiNeutrino)")
+                .Define("FSGenAntiNeutrino_pz", "MCParticle::get_pz(FSGenAntiNeutrino)")
+                .Define("FSGenAntiNeutrino_eta", "MCParticle::get_eta(FSGenAntiNeutrino)")
+                .Define("FSGenAntiNeutrino_theta", "MCParticle::get_theta(FSGenAntiNeutrino)")
+                .Define("FSGenAntiNeutrino_phi", "MCParticle::get_phi(FSGenAntiNeutrino)")
+
+                #all final state gen photons
+                .Define("GenPhoton_PID", "MCParticle::sel_pdgID(22, false)(Particle)")
+                .Define("FSGenPhoton", "MCParticle::sel_genStatus(1)(GenPhoton_PID)") #gen status==1 means final state particle (FS)
+                .Define("n_FSGenPhoton", "MCParticle::get_n(FSGenPhoton)")
+                .Define("FSGenPhoton_e", "MCParticle::get_e(FSGenPhoton)")
+                .Define("FSGenPhoton_p", "MCParticle::get_p(FSGenPhoton)")
+                .Define("FSGenPhoton_pt", "MCParticle::get_pt(FSGenPhoton)")
+                .Define("FSGenPhoton_px", "MCParticle::get_px(FSGenPhoton)")
+                .Define("FSGenPhoton_py", "MCParticle::get_py(FSGenPhoton)")
+                .Define("FSGenPhoton_pz", "MCParticle::get_pz(FSGenPhoton)")
+                .Define("FSGenPhoton_eta", "MCParticle::get_eta(FSGenPhoton)")
+                .Define("FSGenPhoton_theta", "MCParticle::get_theta(FSGenPhoton)")
+                .Define("FSGenPhoton_phi", "MCParticle::get_phi(FSGenPhoton)")
+
+                # Number of final state electrons and positrons when the number of final state photons is only 2
+                # Returns -2 if the number of final state photons != 2, and therefore will be shown as -2 in the plots
+                # .Define("n_FSGenElectron_forFS2GenPhotons", "if (n_FSGenPhoton == 2) {return (n_FSGenElectron); } else {return (-2); }")
+                # .Define("n_FSGenPositron_forFS2GenPhotons", "if (n_FSGenPhoton == 2) {return (n_FSGenPositron); } else {return (-2); }")
+
+                .Define("FSGenPhoton_vertex_x", "MCParticle::get_vertex_x( FSGenPhoton )")
+                .Define("FSGenPhoton_vertex_y", "MCParticle::get_vertex_y( FSGenPhoton )")
+                .Define("FSGenPhoton_vertex_z", "MCParticle::get_vertex_z( FSGenPhoton )")
+
+                # Finding the Lxy of the ALP
+                # Definition: Lxy = math.sqrt( (branchGenPtcl.At(daut1).X)**2 + (branchGenPtcl.At(daut1).Y)**2 )
+                .Define("FSGen_Lxy", "return sqrt(FSGenPhoton_vertex_x*FSGenPhoton_vertex_x + FSGenPhoton_vertex_y*FSGenPhoton_vertex_y)")
+                .Define("FSGen_Lxyz", "return sqrt(FSGenPhoton_vertex_x*FSGenPhoton_vertex_x + FSGenPhoton_vertex_y*FSGenPhoton_vertex_y + FSGenPhoton_vertex_z*FSGenPhoton_vertex_z)")
+
+                # Calculating the lifetime of the ALP
+                # Definition: t = Lxy * branchGenPtcl.At(i).Mass / (branchGenPtcl.At(i).PT * 1000 * 3E8)
+                .Define("FSGen_lifetime_xy", "return ( FSGen_Lxy.at(0) * AllGenALP_mass / (AllGenALP_pt * 3E8 * 1000))" )
+                .Define("FSGen_lifetime_xyz", "return ( FSGen_Lxy.at(0) * AllGenALP_mass / (AllGenALP_p * 3E8 * 1000))" )
+
+                # Separating the three first final state photons
+                # Returns -2 if the number of final state photons != 2, and therefore will be shown as -2 in the plots
+                # .Define("FSGenPhoton0_e", "return FSGenPhoton_e.at(0)")
+                # .Define("FSGenPhoton1_e", "if (n_FSGenPhoton > 2) {return FSGenPhoton_e.at(1);} else {return (-2.0f); }")
+                # .Define("FSGenPhoton2_e", "if (n_FSGenPhoton > 3) {return FSGenPhoton_e.at(2);} else {return (-2.0f); }")
+                # .Define("FSGenPhoton0_p", "return FSGenPhoton_p.at(0)")
+                # .Define("FSGenPhoton1_p", "if (n_FSGenPhoton > 2) {return FSGenPhoton_p.at(1);} else {return (-2.0f); }")
+                # .Define("FSGenPhoton2_p", "if (n_FSGenPhoton > 2) {return FSGenPhoton_p.at(2);} else {return (-2.0f); }")
+                # .Define("FSGenPhoton0_pt", "return FSGenPhoton_pt.at(0)")
+                # .Define("FSGenPhoton1_pt", "if (n_FSGenPhoton > 2) {return FSGenPhoton_pt.at(1);} else {return (-2.0f); }")
+                # .Define("FSGenPhoton2_pt", "if (n_FSGenPhoton > 3) {return FSGenPhoton_pt.at(2);} else {return (-2.0f); }")
+                # .Define("FSGenPhoton0_px", "return FSGenPhoton_px.at(0)")
+                # .Define("FSGenPhoton1_px", "if (n_FSGenPhoton > 2) {return FSGenPhoton_px.at(1);} else {return (-2.0f); }")
+                # .Define("FSGenPhoton2_px", "if (n_FSGenPhoton > 3) {return FSGenPhoton_px.at(2);} else {return (-2.0f); }")
+                # .Define("FSGenPhoton0_py", "return FSGenPhoton_py.at(0)")
+                # .Define("FSGenPhoton1_py", "if (n_FSGenPhoton > 2) {return FSGenPhoton_py.at(1);} else {return (-2.0f); }")
+                # .Define("FSGenPhoton2_py", "if (n_FSGenPhoton > 3) {return FSGenPhoton_py.at(2);} else {return (-2.0f); }")
+                # .Define("FSGenPhoton0_pz", "return FSGenPhoton_pz.at(0)")
+                # .Define("FSGenPhoton1_pz", "if (n_FSGenPhoton > 2) {return FSGenPhoton_pz.at(1);} else {return (-2.0f); }")
+                # .Define("FSGenPhoton2_pz", "if (n_FSGenPhoton > 3) {return FSGenPhoton_pz.at(2);} else {return (-2.0f); }")
+
+                # aa invariant mass - for all three combinations of the three first FS photons
+                # returns -2 for events with only 1 number of photons
+                # .Define("FSGen_a0a1_energy", "return (FSGenPhoton0_e + FSGenPhoton1_e)")
+                # .Define("FSGen_a0a1_px", "return (FSGenPhoton0_px + FSGenPhoton1_px)")
+                # .Define("FSGen_a0a1_py", "return (FSGenPhoton0_py + FSGenPhoton1_py)")
+                # .Define("FSGen_a0a1_pz", "return (FSGenPhoton0_pz + FSGenPhoton1_pz)")
+                # .Define("FSGen_a0a1_invMass", "if (n_FSGenPhoton > 1) { return sqrt(FSGen_a0a1_energy*FSGen_a0a1_energy - FSGen_a0a1_px*FSGen_a0a1_px - FSGen_a0a1_py*FSGen_a0a1_py - FSGen_a0a1_pz*FSGen_a0a1_pz ); } else {return -2.0f;}")
+
+                # .Define("FSGen_a0a2_energy", "return (FSGenPhoton0_e + FSGenPhoton2_e)")
+                # .Define("FSGen_a0a2_px", "return (FSGenPhoton0_px + FSGenPhoton2_px)")
+                # .Define("FSGen_a0a2_py", "return (FSGenPhoton0_py + FSGenPhoton2_py)")
+                # .Define("FSGen_a0a2_pz", "return (FSGenPhoton0_pz + FSGenPhoton2_pz)")
+                # .Define("FSGen_a0a2_invMass", "if (n_FSGenPhoton > 1) { return sqrt(FSGen_a0a2_energy*FSGen_a0a2_energy - FSGen_a0a2_px*FSGen_a0a2_px - FSGen_a0a2_py*FSGen_a0a2_py - FSGen_a0a2_pz*FSGen_a0a2_pz ); } else {return -2.0f;}")
+
+                # .Define("FSGen_a1a2_energy", "return (FSGenPhoton1_e + FSGenPhoton2_e)")
+                # .Define("FSGen_a1a2_px", "return (FSGenPhoton1_px + FSGenPhoton2_px)")
+                # .Define("FSGen_a1a2_py", "return (FSGenPhoton1_py + FSGenPhoton2_py)")
+                # .Define("FSGen_a1a2_pz", "return (FSGenPhoton1_pz + FSGenPhoton2_pz)")
+                # .Define("FSGen_a1a2_invMass", "if (n_FSGenPhoton > 1) { return sqrt(FSGen_a1a2_energy*FSGen_a1a2_energy - FSGen_a1a2_px*FSGen_a1a2_px - FSGen_a1a2_py*FSGen_a1a2_py - FSGen_a1a2_pz*FSGen_a1a2_pz ); } else {return -2.0f;}")
+
+                # aaa invariant mass
+                # Returns -2 for events with only 1 or 2 number of photons
+                # .Define("FSGen_aaa_energy", "return (FSGenPhoton0_e + FSGenPhoton1_e + FSGenPhoton2_e)")
+                # .Define("FSGen_aaa_px", "return (FSGenPhoton0_px + FSGenPhoton1_px + FSGenPhoton2_px)")
+                # .Define("FSGen_aaa_py", "return (FSGenPhoton0_py + FSGenPhoton1_py + FSGenPhoton2_py)")
+                # .Define("FSGen_aaa_pz", "return (FSGenPhoton0_pz + FSGenPhoton1_pz + FSGenPhoton2_pz)")
+                # .Define("FSGen_aaa_invMass", "if (n_FSGenPhoton > 2) { return sqrt(FSGen_aaa_energy*FSGen_aaa_energy - FSGen_aaa_px*FSGen_aaa_px - FSGen_aaa_py*FSGen_aaa_py - FSGen_aaa_pz*FSGen_aaa_pz ); } else {return -2.0f;}")
+
+                # Defining a vector containing the ALP and its daughters in order written
+                # Name of vector is ALP_indices
+                .Define("GenALP_indices", "MCParticle::get_indices(9000005, {22, 22}, true, false, false, true)(Particle, Particle1)")
+                
+                # Defining the individual particles from the vector
+                .Define("GenALP", "myUtils::selMC_leg(0)(GenALP_indices, Particle)")
+                .Define("GenALPPhoton1", "myUtils::selMC_leg(1)(GenALP_indices, Particle)")
+                .Define("GenALPPhoton2", "myUtils::selMC_leg(2)(GenALP_indices, Particle)")
+
+                # Kinematics of the mother particle ALP
+                .Define("GenALP_mass", "MCParticle::get_mass( GenALP )")
+                .Define("GenALP_e", "MCParticle::get_e( GenALP )")
+                .Define("GenALP_p", "MCParticle::get_p( GenALP )")
+                .Define("GenALP_pt", "MCParticle::get_pt( GenALP )")
+                .Define("GenALP_px", "MCParticle::get_px( GenALP )")
+                .Define("GenALP_py", "MCParticle::get_py( GenALP )")
+                .Define("GenALP_pz", "MCParticle::get_pz( GenALP )")
+                .Define("GenALP_eta", "MCParticle::get_eta( GenALP )")
+                .Define("GenALP_theta", "MCParticle::get_theta( GenALP )")
+                .Define("GenALP_phi", "MCParticle::get_phi( GenALP )")
+                .Define("GenALP_genStatus", "MCParticle::get_genStatus( GenALP )")
+
+                # Finding the kinematics of each of these daughters
+                .Define("GenALPPhoton1_e", "MCParticle::get_e( GenALPPhoton1 )")
+                .Define("GenALPPhoton2_e", "MCParticle::get_e( GenALPPhoton2 )")
+                .Define("GenALPPhoton1_p", "MCParticle::get_p( GenALPPhoton1 )")
+                .Define("GenALPPhoton2_p", "MCParticle::get_p( GenALPPhoton2 )")
+                .Define("GenALPPhoton1_pt", "MCParticle::get_pt( GenALPPhoton1 )")
+                .Define("GenALPPhoton2_pt", "MCParticle::get_pt( GenALPPhoton2 )")
+                .Define("GenALPPhoton1_px", "MCParticle::get_px( GenALPPhoton1 )")
+                .Define("GenALPPhoton2_px", "MCParticle::get_px( GenALPPhoton2 )")
+                .Define("GenALPPhoton1_py", "MCParticle::get_py( GenALPPhoton1 )")
+                .Define("GenALPPhoton2_py", "MCParticle::get_py( GenALPPhoton2 )")
+                .Define("GenALPPhoton1_pz", "MCParticle::get_pz( GenALPPhoton1 )")
+                .Define("GenALPPhoton2_pz", "MCParticle::get_pz( GenALPPhoton2 )")
+                .Define("GenALPPhoton1_eta", "MCParticle::get_eta( GenALPPhoton1 )")
+                .Define("GenALPPhoton2_eta", "MCParticle::get_eta( GenALPPhoton2 )")
+                .Define("GenALPPhoton1_theta", "MCParticle::get_theta( GenALPPhoton1 )")
+                .Define("GenALPPhoton2_theta", "MCParticle::get_theta( GenALPPhoton2 )")
+                .Define("GenALPPhoton1_phi", "MCParticle::get_phi( GenALPPhoton1 )")
+                .Define("GenALPPhoton2_phi", "MCParticle::get_phi( GenALPPhoton2 )")
+                .Define("GenALPPhoton1_genStatus", "MCParticle::get_genStatus( GenALPPhoton1 )")
+                .Define("GenALPPhoton2_genStatus", "MCParticle::get_genStatus( GenALPPhoton2 )")
+
+                # Finding the production vertex of the daughters (checking GenALPPhoton1 here)
+                .Define("GenALPPhoton1_vertex_x", "MCParticle::get_vertex_x( GenALPPhoton1 )")
+                .Define("GenALPPhoton1_vertex_y", "MCParticle::get_vertex_y( GenALPPhoton1 )")
+                .Define("GenALPPhoton1_vertex_z", "MCParticle::get_vertex_z( GenALPPhoton1 )")
+
+                # Finding the Lxy of the ALP
+                # Definition: Lxy = math.sqrt( (branchGenPtcl.At(daut1).X)**2 + (branchGenPtcl.At(daut1).Y)**2 )  
+                .Define("GenALP_Lxy", "return sqrt(GenALPPhoton1_vertex_x*GenALPPhoton1_vertex_x + GenALPPhoton1_vertex_y*GenALPPhoton1_vertex_y)")
+                # Finding the Lxyz of the ALP
+                .Define("GenALP_Lxyz", "return sqrt(GenALPPhoton1_vertex_x*GenALPPhoton1_vertex_x + GenALPPhoton1_vertex_y*GenALPPhoton1_vertex_y + GenALPPhoton1_vertex_z*GenALPPhoton1_vertex_z)")
+                
+                # Calculating the lifetime of the ALP
+                # Definition: t = Lxy * branchGenPtcl.At(i).Mass / (branchGenPtcl.At(i).PT * 1000 * 3E8)
+                .Define("GenALP_lifetime_xy", "return ( GenALP_Lxy * GenALP_mass / (GenALP_pt * 3E8 * 1000))" )
+                .Define("GenALP_lifetime_xyz", "return ( GenALP_Lxyz * GenALP_mass / (GenALP_p * 3E8 * 1000))" )
+               
+                # Finding the production vertex of the ALP which should be at (0,0,0) 
+                .Define("GenALP_vertex_x", "MCParticle::get_vertex_x(GenALP_PID)")
+                .Define("GenALP_vertex_y", "MCParticle::get_vertex_y(GenALP_PID)")
+                .Define("GenALP_vertex_z", "MCParticle::get_vertex_z(GenALP_PID)")
+
+                # aa invariant mass
+                .Define("GenALP_aa_energy", "return (GenALPPhoton1_e + GenALPPhoton2_e)")
+                .Define("GenALP_aa_px", "return (GenALPPhoton1_px + GenALPPhoton2_px)")
+                .Define("GenALP_aa_py", "return (GenALPPhoton1_py + GenALPPhoton2_py)")
+                .Define("GenALP_aa_pz", "return (GenALPPhoton1_pz + GenALPPhoton2_pz)")
+                .Define("GenALP_aa_invMass", "return sqrt(GenALP_aa_energy*GenALP_aa_energy - GenALP_aa_px*GenALP_aa_px - GenALP_aa_py*GenALP_aa_py - GenALP_aa_pz*GenALP_aa_pz )")
+
+                # Vertexing studies
+                # Finding the vertex of the mother particle ALP using decicated Bs method
+                #.Define("GenALPMCDecayVertex",   "BsMCDecayVertex( GenALP_indices, Particle )")
+
+                # MC event primary vertex
+                .Define("MC_PrimaryVertex",  "MCParticle::get_EventPrimaryVertex(21)( Particle )" )
+                .Define("n_RecoTracks","ReconstructedParticle2Track::getTK_n(EFlowTrack_1)")
+
+                # Reconstructed particles
+                # Returns the RecoParticles associated with the ALP decay products
+                .Define("RecoALPParticles",  "ReconstructedParticle2MC::selRP_matched_to_list( GenALP_indices, MCRecoAssociations0,MCRecoAssociations1,ReconstructedParticles,Particle)")
+                # Reconstructing the tracks from the ALP
+                .Define("RecoALPTracks",   "ReconstructedParticle2Track::getRP2TRK( RecoALPParticles, EFlowTrack_1)")
+
+                # Number of tracks in this RecoALPTracks collection ( = the #tracks used to reconstruct the ALP reco decay vertex)
+                .Define("n_RecoALPTracks", "ReconstructedParticle2Track::getTK_n( RecoALPTracks )")
+
+                # Now we reconstruct the ALP reco decay vertex using the reco'ed tracks
+                # First the full object, of type Vertexing::FCCAnalysesVertex
+                .Define("RecoALPDecayVertexObject",   "VertexFitterSimple::VertexFitter_Tk( 2, RecoALPTracks)" )
+
+                # from which we extract the edm4hep::VertexData object, which contains the vertex position in mm
+                .Define("RecoALPDecayVertex",  "VertexingUtils::get_VertexData( RecoALPDecayVertexObject )")
+                
+                # We may want to look at the reco'ed ALPs legs: in the RecoALPParticles vector,
+                # the first particle (vector[0]) is the e-, etc :
+                .Define("RecoALPPhoton1",   "myUtils::selRP_leg(0)( RecoALPParticles )")
+                .Define("RecoALPPhoton2",   "myUtils::selRP_leg(1)( RecoALPParticles )")
+                
+                # reconstruced electron, positron values
+                .Define("RecoALPPhoton1_e",  "ReconstructedParticle::get_e( RecoALPPhoton1 )")
+                .Define("RecoALPPhoton2_e",  "ReconstructedParticle::get_e( RecoALPPhoton2 )")
+                .Define("RecoALPPhoton1_p",  "ReconstructedParticle::get_p( RecoALPPhoton1 )")
+                .Define("RecoALPPhoton2_p",  "ReconstructedParticle::get_p( RecoALPPhoton2 )")
+                .Define("RecoALPPhoton1_pt",  "ReconstructedParticle::get_pt( RecoALPPhoton1 )")
+                .Define("RecoALPPhoton2_pt",  "ReconstructedParticle::get_pt( RecoALPPhoton2 )")
+                .Define("RecoALPPhoton1_px",  "ReconstructedParticle::get_px( RecoALPPhoton1 )")
+                .Define("RecoALPPhoton2_px",  "ReconstructedParticle::get_px( RecoALPPhoton2 )")
+                .Define("RecoALPPhoton1_py",  "ReconstructedParticle::get_py( RecoALPPhoton1 )")
+                .Define("RecoALPPhoton2_py",  "ReconstructedParticle::get_py( RecoALPPhoton2 )")
+                .Define("RecoALPPhoton1_pz",  "ReconstructedParticle::get_pz( RecoALPPhoton1 )")
+                .Define("RecoALPPhoton2_pz",  "ReconstructedParticle::get_pz( RecoALPPhoton2 )")
+                .Define("RecoALPPhoton1_eta",  "ReconstructedParticle::get_eta( RecoALPPhoton1 )")
+                .Define("RecoALPPhoton2_eta",  "ReconstructedParticle::get_eta( RecoALPPhoton2 )")
+                .Define("RecoALPPhoton1_theta",  "ReconstructedParticle::get_theta( RecoALPPhoton1 )")
+                .Define("RecoALPPhoton2_theta",  "ReconstructedParticle::get_theta( RecoALPPhoton2 )")
+                .Define("RecoALPPhoton1_phi",  "ReconstructedParticle::get_phi( RecoALPPhoton1 )")
+                .Define("RecoALPPhoton2_phi",  "ReconstructedParticle::get_phi( RecoALPPhoton2 )")
+                .Define("RecoALPPhoton1_charge",  "ReconstructedParticle::get_charge( RecoALPPhoton1 )")
+                .Define("RecoALPPhoton2_charge",  "ReconstructedParticle::get_charge( RecoALPPhoton2 )")
+                # add dxy, dz, dxyz, and uncertainties
+
+                # aa invariant mass
+                .Define("RecoALP_aa_energy", "return (RecoALPPhoton1_e + RecoALPPhoton2_e)")
+                .Define("RecoALP_aa_px", "return (RecoALPPhoton1_px + RecoALPPhoton2_px)")
+                .Define("RecoALP_aa_py", "return (RecoALPPhoton1_py + RecoALPPhoton2_py)")
+                .Define("RecoALP_aa_pz", "return (RecoALPPhoton1_pz + RecoALPPhoton2_pz)")
+                .Define("RecoALP_aa_invMass", "return sqrt(RecoALP_aa_energy*RecoALP_aa_energy - RecoALP_aa_px*RecoALP_aa_px - RecoALP_aa_py*RecoALP_aa_py - RecoALP_aa_pz*RecoALP_aa_pz )")
+
+                #gen-reco
+                .Define("GenMinusRecoALPPhoton1_e",   "GenALPPhoton1_e-RecoALPPhoton1_e")
+                .Define("GenMinusRecoALPPhoton2_e",   "GenALPPhoton2_e-RecoALPPhoton2_e")
+                .Define("GenMinusRecoALPPhoton1_p",   "GenALPPhoton1_p-RecoALPPhoton1_p")
+                .Define("GenMinusRecoALPPhoton2_p",   "GenALPPhoton2_p-RecoALPPhoton2_p")
+                .Define("GenMinusRecoALPPhoton1_pt",   "GenALPPhoton1_pt-RecoALPPhoton1_pt")
+                .Define("GenMinusRecoALPPhoton2_pt",   "GenALPPhoton2_pt-RecoALPPhoton2_pt")
+                .Define("GenMinusRecoALPPhoton1_px",   "GenALPPhoton1_px-RecoALPPhoton1_px")
+                .Define("GenMinusRecoALPPhoton2_px",   "GenALPPhoton2_px-RecoALPPhoton2_px")
+                .Define("GenMinusRecoALPPhoton1_py",   "GenALPPhoton1_py-RecoALPPhoton1_py")
+                .Define("GenMinusRecoALPPhoton2_py",   "GenALPPhoton2_py-RecoALPPhoton2_py")
+                .Define("GenMinusRecoALPPhoton1_pz",   "GenALPPhoton1_pz-RecoALPPhoton1_pz")
+                .Define("GenMinusRecoALPPhoton2_pz",   "GenALPPhoton2_pz-RecoALPPhoton2_pz")
+                .Define("GenMinusRecoALPPhoton1_eta",  "GenALPPhoton1_eta-RecoALPPhoton1_eta")
+                .Define("GenMinusRecoALPPhoton2_eta",  "GenALPPhoton2_eta-RecoALPPhoton2_eta")
+                .Define("GenMinusRecoALPPhoton1_theta",  "GenALPPhoton1_theta-RecoALPPhoton1_theta")
+                .Define("GenMinusRecoALPPhoton2_theta",  "GenALPPhoton2_theta-RecoALPPhoton2_theta")
+                .Define("GenMinusRecoALPPhoton1_phi",  "GenALPPhoton1_phi-RecoALPPhoton1_phi")
+                .Define("GenMinusRecoALPPhoton2_phi",  "GenALPPhoton2_phi-RecoALPPhoton2_phi")
+
+                .Define("GenMinusRecoALP_DecayVertex_x",  "GenALPPhoton1_vertex_x-RecoALPDecayVertex.position.x")
+                .Define("GenMinusRecoALP_DecayVertex_y",  "GenALPPhoton1_vertex_y-RecoALPDecayVertex.position.y")
+                .Define("GenMinusRecoALP_DecayVertex_z",  "GenALPPhoton1_vertex_z-RecoALPDecayVertex.position.z")
+                
+                       
+                ####################################################################################################
+                # From here the general study begins
+
+                #JETS
+                .Define("n_RecoJets", "ReconstructedParticle::get_n(Jet)") #count how many jets are in the event in total
+
+                #PHOTONS
+                .Alias("Photon0", "Photon#0.index") 
+                .Define("RecoPhotons",  "ReconstructedParticle::get(Photon0, ReconstructedParticles)")
+                .Define("n_RecoPhotons",  "ReconstructedParticle::get_n(RecoPhotons)") #count how many photons are in the event in total
+
+                #ELECTRONS AND MUONS
+                #TODO: ADD EXPLANATION OF THE EXTRA STEPS
+                .Alias("Electron0", "Electron#0.index")
+                .Define("RecoElectrons",  "ReconstructedParticle::get(Electron0, ReconstructedParticles)")
+                .Define("n_RecoElectrons",  "ReconstructedParticle::get_n(RecoElectrons)") #count how many electrons are in the event in total
+
+                .Alias("Muon0", "Muon#0.index")
+                .Define("RecoMuons",  "ReconstructedParticle::get(Muon0, ReconstructedParticles)")
+                .Define("n_RecoMuons",  "ReconstructedParticle::get_n(RecoMuons)") #count how many muons are in the event in total
+
+                #OBJECT SELECTION: Consider only those objects that have pt > certain threshold
+                #.Define("selected_jets", "ReconstructedParticle::sel_pt(0.)(Jet)") #select only jets with a pt > 50 GeV
+                #.Define("selected_electrons", "ReconstructedParticle::sel_pt(0.)(electrons)") #select only electrons with a pt > 20 GeV
+                #.Define("selected_photons", "ReconstructedParticle::sel_pt(0.)(photons)") #select only photons with a pt > 20 GeV
+                #.Define("selected_muons", "ReconstructedParticle::sel_pt(0.)(muons)")
+
+                #.Define("n_selJets", "ReconstructedParticle::get_n(selected_jets)")
+                #.Define("n_selElectrons", "ReconstructedParticle::get_n(selected_electrons)")
+                #.Define("n_selPhotons", "ReconstructedParticle::get_n(selected_photons)")
+                #.Define("n_selMuons", "ReconstructedParticle::get_n(selected_muons)")
+
+                #SIMPLE VARIABLES: Access the basic kinematic variables of the (selected) jets, works analogously for electrons, muons
+                .Define("RecoJet_e",      "ReconstructedParticle::get_e(Jet)")
+                .Define("RecoJet_p",      "ReconstructedParticle::get_p(Jet)") #momentum p
+                .Define("RecoJet_pt",      "ReconstructedParticle::get_pt(Jet)") #transverse momentum pt
+                .Define("RecoJet_px",      "ReconstructedParticle::get_px(Jet)")
+                .Define("RecoJet_py",      "ReconstructedParticle::get_py(Jet)")
+                .Define("RecoJet_pz",      "ReconstructedParticle::get_pz(Jet)")
+                .Define("RecoJet_eta",     "ReconstructedParticle::get_eta(Jet)") #pseudorapidity eta
+                .Define("RecoJet_theta",   "ReconstructedParticle::get_theta(Jet)")
+                .Define("RecoJet_phi",     "ReconstructedParticle::get_phi(Jet)") #polar angle in the transverse plane phi
+                .Define("RecoJet_charge",  "ReconstructedParticle::get_charge(Jet)")
+
+                .Define("RecoElectron_e",      "ReconstructedParticle::get_e(RecoElectrons)")
+                .Define("RecoElectron_p",      "ReconstructedParticle::get_p(RecoElectrons)")
+                .Define("RecoElectron_pt",      "ReconstructedParticle::get_pt(RecoElectrons)")
+                .Define("RecoElectron_px",      "ReconstructedParticle::get_px(RecoElectrons)")
+                .Define("RecoElectron_py",      "ReconstructedParticle::get_py(RecoElectrons)")
+                .Define("RecoElectron_pz",      "ReconstructedParticle::get_pz(RecoElectrons)")
+                .Define("RecoElectron_eta",     "ReconstructedParticle::get_eta(RecoElectrons)") #pseudorapidity eta
+                .Define("RecoElectron_theta",   "ReconstructedParticle::get_theta(RecoElectrons)")
+                .Define("RecoElectron_phi",     "ReconstructedParticle::get_phi(RecoElectrons)") #polar angle in the transverse plane phi
+                .Define("RecoElectron_charge",  "ReconstructedParticle::get_charge(RecoElectrons)")
+
+                .Define("RecoPhoton_e",      "ReconstructedParticle::get_e(RecoPhotons)")
+                .Define("RecoPhoton_p",      "ReconstructedParticle::get_p(RecoPhotons)")
+                .Define("RecoPhoton_pt",      "ReconstructedParticle::get_pt(RecoPhotons)")
+                .Define("RecoPhoton_px",      "ReconstructedParticle::get_px(RecoPhotons)")
+                .Define("RecoPhoton_py",      "ReconstructedParticle::get_py(RecoPhotons)")
+                .Define("RecoPhoton_pz",      "ReconstructedParticle::get_pz(RecoPhotons)")
+                .Define("RecoPhoton_eta",     "ReconstructedParticle::get_eta(RecoPhotons)") #pseudorapidity eta
+                .Define("RecoPhoton_theta",   "ReconstructedParticle::get_theta(RecoPhotons)")
+                .Define("RecoPhoton_phi",     "ReconstructedParticle::get_phi(RecoPhotons)") #polar angle in the transverse plane phi
+                .Define("RecoPhoton_charge",  "ReconstructedParticle::get_charge(RecoPhotons)")
+
+                .Define("RecoMuon_e",      "ReconstructedParticle::get_e(RecoMuons)")
+                .Define("RecoMuon_p",      "ReconstructedParticle::get_p(RecoMuons)")
+                .Define("RecoMuon_pt",      "ReconstructedParticle::get_pt(RecoMuons)")
+                .Define("RecoMuon_px",      "ReconstructedParticle::get_px(RecoMuons)")
+                .Define("RecoMuon_py",      "ReconstructedParticle::get_py(RecoMuons)")
+                .Define("RecoMuon_pz",      "ReconstructedParticle::get_pz(RecoMuons)")
+                .Define("RecoMuon_eta",     "ReconstructedParticle::get_eta(RecoMuons)") #pseudorapidity eta
+                .Define("RecoMuon_theta",   "ReconstructedParticle::get_theta(RecoMuons)")
+                .Define("RecoMuon_phi",     "ReconstructedParticle::get_phi(RecoMuons)") #polar angle in the transverse plane phi
+                .Define("RecoMuon_charge",  "ReconstructedParticle::get_charge(RecoMuons)")
+
+                #EVENTWIDE VARIABLES: Access quantities that exist only once per event, such as the missing energy (despite the name, the MissingET collection contains the total missing energy)
+                .Define("RecoMissingEnergy_e", "ReconstructedParticle::get_e(MissingET)")
+                .Define("RecoMissingEnergy_p", "ReconstructedParticle::get_p(MissingET)")
+                .Define("RecoMissingEnergy_pt", "ReconstructedParticle::get_pt(MissingET)")
+                .Define("RecoMissingEnergy_px", "ReconstructedParticle::get_px(MissingET)")
+                .Define("RecoMissingEnergy_py", "ReconstructedParticle::get_py(MissingET)")
+                .Define("RecoMissingEnergy_pz", "ReconstructedParticle::get_pz(MissingET)")
+                .Define("RecoMissingEnergy_eta", "ReconstructedParticle::get_eta(MissingET)")
+                .Define("RecoMissingEnergy_theta", "ReconstructedParticle::get_theta(MissingET)")
+                .Define("RecoMissingEnergy_phi", "ReconstructedParticle::get_phi(MissingET)")
+
+
+               )
+                return df2
+
+        def output():
+                branchList = [
+                        ######## Monte-Carlo particles #######
+                        "All_n_GenALP",
+                        "AllGenALP_mass",
+                        "AllGenALP_e",
+                        "AllGenALP_p",
+                        "AllGenALP_pt",
+                        "AllGenALP_px",
+                        "AllGenALP_py",
+                        "AllGenALP_pz",
+                        "AllGenALP_eta",
+                        "AllGenALP_theta",
+                        "AllGenALP_phi",
+                        "AllGenALP_genStatus",
+                        "n_FSGenElectron",
+                        "FSGenElectron_e",
+                        "FSGenElectron_p",
+                        "FSGenElectron_pt",
+                        "FSGenElectron_px",
+                        "FSGenElectron_py",
+                        "FSGenElectron_pz",
+                        "FSGenElectron_eta",
+                        "FSGenElectron_theta",
+                        "FSGenElectron_phi",
+                        "FSGenPhoton_vertex_x",
+                        "FSGenPhoton_vertex_y",
+                        "FSGenPhoton_vertex_z",
+                        # "n_FSGenElectron_forFS2GenPhotons",
+                        # "n_FSGenPositron_forFS2GenPhotons",
+                        "FSGen_Lxy",
+                        "FSGen_Lxyz",
+                        "FSGen_lifetime_xy",
+                        "FSGen_lifetime_xyz",
+                        "n_FSGenPositron",
+                        "FSGenPositron_e",
+                        "FSGenPositron_p",
+                        "FSGenPositron_pt",
+                        "FSGenPositron_px",
+                        "FSGenPositron_py",
+                        "FSGenPositron_pz",
+                        "FSGenPositron_eta",
+                        "FSGenPositron_theta",
+                        "FSGenPositron_phi",
+                        "n_FSGenNeutrino",
+                        "FSGenNeutrino_e",
+                        "FSGenNeutrino_p",
+                        "FSGenNeutrino_pt",
+                        "FSGenNeutrino_px",
+                        "FSGenNeutrino_py",
+                        "FSGenNeutrino_pz",
+                        "FSGenNeutrino_eta",
+                        "FSGenNeutrino_theta",
+                        "FSGenNeutrino_phi",
+                        "n_FSGenAntiNeutrino",
+                        "FSGenAntiNeutrino_e",
+                        "FSGenAntiNeutrino_p",
+                        "FSGenAntiNeutrino_pt",
+                        "FSGenAntiNeutrino_px",
+                        "FSGenAntiNeutrino_py",
+                        "FSGenAntiNeutrino_pz",
+                        "FSGenAntiNeutrino_eta",
+                        "FSGenAntiNeutrino_theta",
+                        "FSGenAntiNeutrino_phi",
+                        "n_FSGenPhoton",
+                        "FSGenPhoton_e",
+                        "FSGenPhoton_p",
+                        "FSGenPhoton_pt",
+                        "FSGenPhoton_px",
+                        "FSGenPhoton_py",
+                        "FSGenPhoton_pz",
+                        "FSGenPhoton_eta",
+                        "FSGenPhoton_theta",
+                        "FSGenPhoton_phi",
+                        # "FSGenPhoton0_e",
+                        # "FSGenPhoton1_e",
+                        # "FSGenPhoton2_e",
+                        # "FSGenPhoton0_p",
+                        # "FSGenPhoton1_p",
+                        # "FSGenPhoton2_p",
+                        # "FSGenPhoton0_pt",
+                        # "FSGenPhoton1_pt",
+                        # "FSGenPhoton2_pt",
+                        # "FSGen_a0a1_invMass",
+                        # "FSGen_a0a2_invMass",
+                        # "FSGen_a1a2_invMass",
+                        # "FSGen_aaa_invMass",
+                        "GenALP_vertex_x",
+                        "GenALP_vertex_y",
+                        "GenALP_vertex_z",
+                        "GenALP_aa_invMass",
+                        "GenALP_mass",
+                        "GenALP_p",
+                        "GenALP_pt",
+                        "GenALP_pz",
+                        "GenALP_eta",
+                        "GenALP_theta",
+                        "GenALP_phi",
+                        "GenALP_genStatus",
+                        "GenALPPhoton1_e",
+                        "GenALPPhoton2_e",
+                        "GenALPPhoton1_p",
+                        "GenALPPhoton2_p",
+                        "GenALPPhoton1_pt",
+                        "GenALPPhoton2_pt",
+                        "GenALPPhoton1_px",
+                        "GenALPPhoton2_px",
+                        "GenALPPhoton1_py",
+                        "GenALPPhoton2_py",
+                        "GenALPPhoton1_pz",
+                        "GenALPPhoton2_pz",
+                        "GenALPPhoton1_eta",
+                        "GenALPPhoton2_eta",
+                        "GenALPPhoton1_theta",
+                        "GenALPPhoton2_theta",
+                        "GenALPPhoton1_phi",
+                        "GenALPPhoton2_phi",
+                        "GenALPPhoton1_genStatus",
+                        "GenALPPhoton2_genStatus",
+                        #"GenALP_decay",
+                        "GenALPPhoton1_vertex_x",
+                        "GenALPPhoton1_vertex_y",
+                        "GenALPPhoton1_vertex_z",
+                        "GenALP_Lxy",
+                        "GenALP_Lxyz",
+                        "GenALP_lifetime_xy",
+                        "GenALP_lifetime_xyz",
+                        #"GenALPMCDecayVertex",
+                        "MC_PrimaryVertex",
+                        "n_RecoTracks",
+                        ######## Reconstructed particles #######
+                        "RecoALPParticles",
+                        "RecoALPTracks",
+                        "n_RecoALPTracks",
+                        "RecoALPDecayVertexObject",
+                        "RecoALPDecayVertex",
+                        "RecoALPPhoton1_e",
+                        "RecoALPPhoton2_e",
+                        "RecoALPPhoton1_p",
+                        "RecoALPPhoton2_p",
+                        "RecoALPPhoton1_pt",
+                        "RecoALPPhoton2_pt",
+                        "RecoALPPhoton1_px",
+                        "RecoALPPhoton2_px",
+                        "RecoALPPhoton1_py",
+                        "RecoALPPhoton2_py",
+                        "RecoALPPhoton1_pz",
+                        "RecoALPPhoton2_pz",
+                        "RecoALPPhoton1_eta",
+                        "RecoALPPhoton2_eta",
+                        "RecoALPPhoton1_theta",
+                        "RecoALPPhoton2_theta",
+                        "RecoALPPhoton1_phi",
+                        "RecoALPPhoton2_phi",
+                        "RecoALPPhoton1_charge",
+                        "RecoALPPhoton2_charge",
+                        "RecoALP_aa_invMass",
+                        "GenMinusRecoALPPhoton1_e",
+                        "GenMinusRecoALPPhoton2_e",
+                        "GenMinusRecoALPPhoton1_p",
+                        "GenMinusRecoALPPhoton2_p",
+                        "GenMinusRecoALPPhoton1_pt",
+                        "GenMinusRecoALPPhoton2_pt",
+                        "GenMinusRecoALPPhoton1_px",
+                        "GenMinusRecoALPPhoton2_px",
+                        "GenMinusRecoALPPhoton1_py",
+                        "GenMinusRecoALPPhoton2_py",
+                        "GenMinusRecoALPPhoton1_pz",
+                        "GenMinusRecoALPPhoton2_pz",
+                        "GenMinusRecoALPPhoton1_eta",
+                        "GenMinusRecoALPPhoton2_eta",
+                        "GenMinusRecoALPPhoton1_theta",
+                        "GenMinusRecoALPPhoton2_theta",
+                        "GenMinusRecoALPPhoton1_phi",
+                        "GenMinusRecoALPPhoton2_phi",
+                        "GenMinusRecoALP_DecayVertex_x",
+                        "GenMinusRecoALP_DecayVertex_y",
+                        "GenMinusRecoALP_DecayVertex_z",
+                        "n_RecoJets",
+                        "n_RecoPhotons",
+                        "n_RecoElectrons",
+                        "n_RecoMuons",
+                        "RecoJet_e",
+                        "RecoJet_p",
+                        "RecoJet_pt",
+                        "RecoJet_px",
+                        "RecoJet_py",
+                        "RecoJet_pz",
+                        "RecoJet_eta",
+                        "RecoJet_theta",
+                        "RecoJet_phi",
+                        "RecoJet_charge",
+                        "RecoPhoton_e",
+                        "RecoPhoton_p",
+                        "RecoPhoton_pt",
+                        "RecoPhoton_px",
+                        "RecoPhoton_py",
+                        "RecoPhoton_pz",
+                        "RecoPhoton_eta",
+                        "RecoPhoton_theta",
+                        "RecoPhoton_phi",
+                        "RecoPhoton_charge",
+                        "RecoElectron_e",
+                        "RecoElectron_p",
+                        "RecoElectron_pt",
+                        "RecoElectron_px",
+                        "RecoElectron_py",
+                        "RecoElectron_pz",
+                        "RecoElectron_eta",
+                        "RecoElectron_theta",
+                        "RecoElectron_phi",
+                        "RecoElectron_charge",
+                        "RecoMuon_e",
+                        "RecoMuon_p",
+                        "RecoMuon_pt",
+                        "RecoMuon_px",
+                        "RecoMuon_py",
+                        "RecoMuon_pz",
+                        "RecoMuon_eta",
+                        "RecoMuon_theta",
+                        "RecoMuon_phi",
+                        "RecoMuon_charge",
+                        "RecoMissingEnergy_e",
+                        "RecoMissingEnergy_p",
+                        "RecoMissingEnergy_pt",
+                        "RecoMissingEnergy_px",
+                        "RecoMissingEnergy_py",
+                        "RecoMissingEnergy_pz",
+                        "RecoMissingEnergy_eta",
+                        "RecoMissingEnergy_theta",
+                        "RecoMissingEnergy_phi",
+		]
+
+                return branchList


### PR DESCRIPTION
This PR:
- makes minor updates to the ALP madgraph/pythia/delphes creation code
- adds selectors to choose reco particle decay legs to myUtils (applicable to ALPs and other signatures)
- migrates the ALP analysis code to FCCAnalyses