### PR TITLE
Adding for code for exotic Higgs analysis for CLD, hadronic/invisible Z decay samples 

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/ReconstructedParticle.h
+++ b/analyzers/dataframe/FCCAnalyses/ReconstructedParticle.h
@@ -169,6 +169,21 @@ namespace ReconstructedParticle{
   /// get number of b-jets
   int getJet_ntags(ROOT::VecOps::RVec<bool> in);
 
+    // get sum of vector of floats
+  float get_sum_float(ROOT::VecOps::RVec<float> in);
+
+  // get sum of vector of ints 
+  int get_sum_int(ROOT::VecOps::RVec<int> in);
+
+  // get avg of vector of floats
+  float get_avg_float(ROOT::VecOps::RVec<float> in);
+
+  // get avg of vector of ints
+  int get_avg_int(ROOT::VecOps::RVec<float> in);
+
+  /// return the summed total energy of all of the input ReconstructedParticles
+  float get_total_e(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in);
+
 }//end NS ReconstructedParticle
 
 }//end NS FCCAnalyses

--- a/analyzers/dataframe/FCCAnalyses/VertexingUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/VertexingUtils.h
@@ -107,7 +107,11 @@ namespace VertexingUtils{
   /// Retrieve the indices of the tracks fitted to that vertex, but now in the collection of RecoParticles
   ROOT::VecOps::RVec<int> get_VertexRecoParticlesInd( FCCAnalysesVertex TheVertex, 
 						      const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& reco );
- 
+
+  /// Retrieve the indices of the tracks fitted to a vector of vertices, but now in the collection of RecoParticles
+  ROOT::VecOps::RVec<int> get_VerticesRecoParticlesInd( ROOT::VecOps::RVec<FCCAnalysesVertex > vertices, 
+						      const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& reco );
+
   /// Return the number of tracks in a given track collection
   int get_nTracks(ROOT::VecOps::RVec<edm4hep::TrackState> tracks);
 

--- a/analyzers/dataframe/src/ReconstructedParticle.cc
+++ b/analyzers/dataframe/src/ReconstructedParticle.cc
@@ -348,6 +348,14 @@ ROOT::VecOps::RVec<float> get_e(ROOT::VecOps::RVec<edm4hep::ReconstructedParticl
   return result;
 }
 
+float get_total_e(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in){
+  float result;
+  for (auto & p: in) {
+    result += p.energy;
+  }
+  return result;
+}
+
 ROOT::VecOps::RVec<float> get_p(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in) {
   ROOT::VecOps::RVec<float> result;
   for (auto & p: in) {
@@ -474,6 +482,49 @@ int getJet_ntags(ROOT::VecOps::RVec<bool> in) {
     if (in.at(i))result+=1;
   return result;
 }
+
+ float get_sum_float(ROOT::VecOps::RVec<float> in){
+    float result = std::accumulate(in.begin(), in.end(), 0.0f);
+    //float result = 0;
+    //for (int i; i < in.size(); ++i){
+    //  result += in[i];
+    //}
+    return result;
+  }
+
+  // get sum of int 
+  int get_sum_int(ROOT::VecOps::RVec<int> in){
+    int result = std::accumulate(in.begin(), in.end(), 0);
+    //int result = 0;
+    //for (int i; i < in.size(); ++i){
+    //  result += in[i];
+    //}
+    return result;
+  }
+
+  // get avg of floats
+  float get_avg_float(ROOT::VecOps::RVec<float> in){
+    //float result;
+    //for (int i; i < in.size(); ++i){
+    //  result += in[i];
+    //}
+    float result = std::accumulate(in.begin(), in.end(), 0.0f) / in.size();
+    //result /= in.size(); 
+    return result;
+  }
+
+  // get avg of ints
+  int get_avg_int(ROOT::VecOps::RVec<float> in){
+    //int result;
+    //for (int i; i < in.size(); ++i){
+    //  result += in[i];
+    //}
+    //result /= in.size(); 
+    int result = std::accumulate(in.begin(), in.end(), 0.0f) / in.size();
+    return result;
+  }
+
+
 
 }//end NS ReconstructedParticle
 

--- a/analyzers/dataframe/src/VertexFinderLCFIPlus.cc
+++ b/analyzers/dataframe/src/VertexFinderLCFIPlus.cc
@@ -307,10 +307,10 @@ ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> findSVfromTracks(ROOT::Vec
     VertexingUtils::FCCAnalysesVertex sec_vtx = VertexFitterSimple::VertexFitter_Tk(2, tr_vtx_fin, alltracks); // flag 2 for SVs
 
     // save the tracks that are used to fit the SV
-    sec_vtx.tracks = tr_vtx_fin;
+    //sec_vtx.tracks = tr_vtx_fin;
 
     // save the tracks that are used to fit the SV
-    sec_vtx.tracks = tr_vtx_fin;
+    //sec_vtx.tracks = tr_vtx_fin;
 
     // see if we can also get indices in the reco collection (for tracks forming an SV)
     //sec_vtx.reco_ind = VertexFitterSimple::get_reco_ind(recoparticles,thetracks); // incorrect

--- a/analyzers/dataframe/src/VertexingUtils.cc
+++ b/analyzers/dataframe/src/VertexingUtils.cc
@@ -369,6 +369,31 @@ ROOT::VecOps::RVec<int> get_VertexRecoParticlesInd(
   return result;
 }
 
+ROOT::VecOps::RVec<int> get_VerticesRecoParticlesInd(
+    ROOT::VecOps::RVec<FCCAnalysesVertex > vertices,
+    const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> &reco) {
+
+  ROOT::VecOps::RVec<int> result;
+  for (int j = 0; j < vertices.size(); ++j){
+    ROOT::VecOps::RVec<int> indices_tracks = vertices[j].reco_ind;
+    for (int i = 0; i < indices_tracks.size(); i++) {
+      int tk_index = indices_tracks[i];
+      for (int j = 0; j < reco.size(); j++) {
+        auto &p = reco[j];
+        if (p.tracks_begin == p.tracks_end)
+          continue;
+        if (p.tracks_begin == tk_index) {
+          result.push_back(j);
+          break;
+        }
+      }
+    }
+  }
+  
+  return result;
+}
+
+
 TVectorD ParToACTS(TVectorD Par) {
 
   TVectorD pACTS(6); // Return vector

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS20GeV_WHSe-14_proc_card_H.dat
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS20GeV_WHSe-14_proc_card_H.dat
@@ -1,0 +1,88 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 3.4.1                 2022-09-01         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set low_mem_multicore_nlo_generation False
+set complex_mass_scheme False
+set include_lepton_initiated_processes False
+set gauge unitary
+set loop_optimized_output True
+set loop_color_flows False
+set max_npoint_for_channel 0
+set default_unset_couplings 99
+set max_t_for_channel 99
+set zerowidth_tchannel True
+set nlo_mixed_expansion True
+import model sm
+
+set auto_convert_model T
+import model --modelname HAHM_variableMW_v3_UFO/
+define l+ = e+ m+
+define l- = e- m-
+define q = u c d s b
+define q~ = u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt-
+
+#*** generate the process: e+ e- -> Z -> Z h with Z -> q q~ and h -> 2hs -> 4b
+generate e+ e- > z > z h, z > q q~, (h > hs hs, hs > b b~)
+
+output h_2hs_4b_mhs20GeV_WHSe-14_H
+
+# launch the event generation
+launch
+
+#*** set electron beams and the center-of-mass energy to the ZH maximum production peak (240 GeV), i.e 120 GeV per electron beam
+
+# set beam type; 0 for electron, 1 for proton	
+set lpp1 0
+set lpp2 0
+# set total energy in GeV for each beam 
+set ebeam1 120		
+set ebeam2 120
+
+#*** set model parameters; couplings and masses
+
+# the model accounts both dark scalars and dark photons, hence set the kinetic mixing coupling epsilon to zero and mass of dark photon high (to only simulate SM + dark scalar singlet)
+set epsilon 1.000000e-10
+set mZDinput 1.000000e+03
+
+# set the mass of the dark scalar
+set MHSinput 20.000000e+00
+
+# set singlet-higgs coupling
+set kap 7.000000e-04
+
+# set the decay width to O(e-14) s.t sin^2 theta = O(e-10) and decay length O(mm)
+set whs 5.7793e-14
+
+# set the width of the higgs and the dark photon to auto
+set wh Auto
+set wzp Auto
+
+# needed to get llp
+set time_of_flight 0
+
+# set number of events
+set nevents 10000
+
+done

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS20GeV_WHSe-14_proc_card_NU.dat
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS20GeV_WHSe-14_proc_card_NU.dat
@@ -1,0 +1,88 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 3.4.1                 2022-09-01         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set low_mem_multicore_nlo_generation False
+set complex_mass_scheme False
+set include_lepton_initiated_processes False
+set gauge unitary
+set loop_optimized_output True
+set loop_color_flows False
+set max_npoint_for_channel 0
+set default_unset_couplings 99
+set max_t_for_channel 99
+set zerowidth_tchannel True
+set nlo_mixed_expansion True
+import model sm
+
+set auto_convert_model T
+import model --modelname HAHM_variableMW_v3_UFO/
+define l+ = e+ m+
+define l- = e- m-
+define q = u c d s b
+define q~ = u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt-
+
+#*** generate the process: e+ e- -> Z -> Z h with Z -> q q~ and h -> 2hs -> 4b
+generate e+ e- > z > z h, z > vl vl~, (h > hs hs, hs > b b~)
+
+output h_2hs_4b_mhs20GeV_WHSe-14_NU
+
+# launch the event generation
+launch
+
+#*** set electron beams and the center-of-mass energy to the ZH maximum production peak (240 GeV), i.e 120 GeV per electron beam
+
+# set beam type; 0 for electron, 1 for proton	
+set lpp1 0
+set lpp2 0
+# set total energy in GeV for each beam 
+set ebeam1 120		
+set ebeam2 120
+
+#*** set model parameters; couplings and masses
+
+# the model accounts both dark scalars and dark photons, hence set the kinetic mixing coupling epsilon to zero and mass of dark photon high (to only simulate SM + dark scalar singlet)
+set epsilon 1.000000e-10
+set mZDinput 1.000000e+03
+
+# set the mass of the dark scalar
+set MHSinput 20.000000e+00
+
+# set singlet-higgs coupling
+set kap 7.000000e-04
+
+# set the decay width to O(e-14) s.t sin^2 theta = O(e-10) and decay length O(mm)
+set whs 5.7793e-14
+
+# set the width of the higgs and the dark photon to auto
+set wh Auto
+set wzp Auto
+
+# needed to get llp
+set time_of_flight 0
+
+# set number of events
+set nevents 10000
+
+done

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS20GeV_WHSe-16_proc_card_H.dat
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS20GeV_WHSe-16_proc_card_H.dat
@@ -1,0 +1,88 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 3.4.1                 2022-09-01         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set low_mem_multicore_nlo_generation False
+set complex_mass_scheme False
+set include_lepton_initiated_processes False
+set gauge unitary
+set loop_optimized_output True
+set loop_color_flows False
+set max_npoint_for_channel 0
+set default_unset_couplings 99
+set max_t_for_channel 99
+set zerowidth_tchannel True
+set nlo_mixed_expansion True
+import model sm
+
+set auto_convert_model T
+import model --modelname HAHM_variableMW_v3_UFO/
+define l+ = e+ m+
+define l- = e- m-
+define q = u c d s b
+define q~ = u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt-
+
+#*** generate the process: e+ e- -> Z -> Z h with Z -> q q~ and h -> 2hs -> 4b
+generate e+ e- > z > z h, z > q q~, (h > hs hs, hs > b b~)
+
+output h_2hs_4b_mhs20GeV_WHSe-16_H
+
+# launch the event generation
+launch
+
+#*** set electron beams and the center-of-mass energy to the ZH maximum production peak (240 GeV), i.e 120 GeV per electron beam
+
+# set beam type; 0 for electron, 1 for proton	
+set lpp1 0
+set lpp2 0
+# set total energy in GeV for each beam 
+set ebeam1 120		
+set ebeam2 120
+
+#*** set model parameters; couplings and masses
+
+# the model accounts both dark scalars and dark photons, hence set the kinetic mixing coupling epsilon to zero and mass of dark photon high (to only simulate SM + dark scalar singlet)
+set epsilon 1.000000e-10
+set mZDinput 1.000000e+03
+
+# set the mass of the dark scalar
+set MHSinput 20.000000e+00
+
+# set singlet-higgs coupling
+set kap 7.000000e-04
+
+# set the decay width to O(e-16) s.t sin^2 theta = O(e-12) and decay length O(100 mm)
+set whs 5.7793e-16
+
+# set the width of the higgs and the dark photon to auto
+set wh Auto
+set wzp Auto
+
+# needed to get llp
+set time_of_flight 0
+
+# set number of events
+set nevents 10000
+
+done

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS20GeV_WHSe-16_proc_card_NU.dat
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS20GeV_WHSe-16_proc_card_NU.dat
@@ -1,0 +1,88 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 3.4.1                 2022-09-01         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set low_mem_multicore_nlo_generation False
+set complex_mass_scheme False
+set include_lepton_initiated_processes False
+set gauge unitary
+set loop_optimized_output True
+set loop_color_flows False
+set max_npoint_for_channel 0
+set default_unset_couplings 99
+set max_t_for_channel 99
+set zerowidth_tchannel True
+set nlo_mixed_expansion True
+import model sm
+
+set auto_convert_model T
+import model --modelname HAHM_variableMW_v3_UFO/
+define l+ = e+ m+
+define l- = e- m-
+define q = u c d s b
+define q~ = u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt-
+
+#*** generate the process: e+ e- -> Z -> Z h with Z -> q q~ and h -> 2hs -> 4b
+generate e+ e- > z > z h, z > vl vl~, (h > hs hs, hs > b b~)
+
+output h_2hs_4b_mhs20GeV_WHSe-16_NU
+
+# launch the event generation
+launch
+
+#*** set electron beams and the center-of-mass energy to the ZH maximum production peak (240 GeV), i.e 120 GeV per electron beam
+
+# set beam type; 0 for electron, 1 for proton	
+set lpp1 0
+set lpp2 0
+# set total energy in GeV for each beam 
+set ebeam1 120		
+set ebeam2 120
+
+#*** set model parameters; couplings and masses
+
+# the model accounts both dark scalars and dark photons, hence set the kinetic mixing coupling epsilon to zero and mass of dark photon high (to only simulate SM + dark scalar singlet)
+set epsilon 1.000000e-10
+set mZDinput 1.000000e+03
+
+# set the mass of the dark scalar
+set MHSinput 20.000000e+00
+
+# set singlet-higgs coupling
+set kap 7.000000e-04
+
+# set the decay width to O(e-16) s.t sin^2 theta = O(e-12) and decay length O(100 mm)
+set whs 5.7793e-16
+
+# set the width of the higgs and the dark photon to auto
+set wh Auto
+set wzp Auto
+
+# needed to get llp
+set time_of_flight 0
+
+# set number of events
+set nevents 10000
+
+done

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS20GeV_WHSe-18_proc_card_H.dat
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS20GeV_WHSe-18_proc_card_H.dat
@@ -1,0 +1,88 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 3.4.1                 2022-09-01         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set low_mem_multicore_nlo_generation False
+set complex_mass_scheme False
+set include_lepton_initiated_processes False
+set gauge unitary
+set loop_optimized_output True
+set loop_color_flows False
+set max_npoint_for_channel 0
+set default_unset_couplings 99
+set max_t_for_channel 99
+set zerowidth_tchannel True
+set nlo_mixed_expansion True
+import model sm
+
+set auto_convert_model T
+import model --modelname HAHM_variableMW_v3_UFO/
+define l+ = e+ m+
+define l- = e- m-
+define q = u c d s b
+define q~ = u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt-
+
+#*** generate the process: e+ e- -> Z -> Z h with Z -> q q~ and h -> 2hs -> 4b
+generate e+ e- > z > z h, z > q q~, (h > hs hs, hs > b b~)
+
+output h_2hs_4b_mhs20GeV_WHSe-18_H
+
+# launch the event generation
+launch
+
+#*** set electron beams and the center-of-mass energy to the ZH maximum production peak (240 GeV), i.e 120 GeV per electron beam
+
+# set beam type; 0 for electron, 1 for proton	
+set lpp1 0
+set lpp2 0
+# set total energy in GeV for each beam 
+set ebeam1 120		
+set ebeam2 120
+
+#*** set model parameters; couplings and masses
+
+# the model accounts both dark scalars and dark photons, hence set the kinetic mixing coupling epsilon to zero and mass of dark photon high (to only simulate SM + dark scalar singlet)
+set epsilon 1.000000e-10
+set mZDinput 1.000000e+03
+
+# set the mass of the dark scalar
+set MHSinput 20.000000e+00
+
+# set singlet-higgs coupling
+set kap 7.000000e-04
+
+# set the decay width to O(e-18) s.t sin^2 theta = O(e-14) and decay length O(10 m)
+set whs 5.7793e-18
+
+# set the width of the higgs and the dark photon to auto
+set wh Auto
+set wzp Auto
+
+# needed to get llp
+set time_of_flight 0
+
+# set number of events
+set nevents 10000
+
+done

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS20GeV_WHSe-18_proc_card_NU.dat
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS20GeV_WHSe-18_proc_card_NU.dat
@@ -1,0 +1,88 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 3.4.1                 2022-09-01         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set low_mem_multicore_nlo_generation False
+set complex_mass_scheme False
+set include_lepton_initiated_processes False
+set gauge unitary
+set loop_optimized_output True
+set loop_color_flows False
+set max_npoint_for_channel 0
+set default_unset_couplings 99
+set max_t_for_channel 99
+set zerowidth_tchannel True
+set nlo_mixed_expansion True
+import model sm
+
+set auto_convert_model T
+import model --modelname HAHM_variableMW_v3_UFO/
+define l+ = e+ m+
+define l- = e- m-
+define q = u c d s b
+define q~ = u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt-
+
+#*** generate the process: e+ e- -> Z -> Z h with Z -> q q~ and h -> 2hs -> 4b
+generate e+ e- > z > z h, z > vl vl~, (h > hs hs, hs > b b~)
+
+output h_2hs_4b_mhs20GeV_WHSe-18_NU
+
+# launch the event generation
+launch
+
+#*** set electron beams and the center-of-mass energy to the ZH maximum production peak (240 GeV), i.e 120 GeV per electron beam
+
+# set beam type; 0 for electron, 1 for proton	
+set lpp1 0
+set lpp2 0
+# set total energy in GeV for each beam 
+set ebeam1 120		
+set ebeam2 120
+
+#*** set model parameters; couplings and masses
+
+# the model accounts both dark scalars and dark photons, hence set the kinetic mixing coupling epsilon to zero and mass of dark photon high (to only simulate SM + dark scalar singlet)
+set epsilon 1.000000e-10
+set mZDinput 1.000000e+03
+
+# set the mass of the dark scalar
+set MHSinput 20.000000e+00
+
+# set singlet-higgs coupling
+set kap 7.000000e-04
+
+# set the decay width to O(e-18) s.t sin^2 theta = O(e-14) and decay length O(10 m)
+set whs 5.7793e-18
+
+# set the width of the higgs and the dark photon to auto
+set wh Auto
+set wzp Auto
+
+# needed to get llp
+set time_of_flight 0
+
+# set number of events
+set nevents 10000
+
+done

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS60GeV_WHSe-13_proc_card_H.dat
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS60GeV_WHSe-13_proc_card_H.dat
@@ -1,0 +1,88 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 3.4.1                 2022-09-01         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set low_mem_multicore_nlo_generation False
+set complex_mass_scheme False
+set include_lepton_initiated_processes False
+set gauge unitary
+set loop_optimized_output True
+set loop_color_flows False
+set max_npoint_for_channel 0
+set default_unset_couplings 99
+set max_t_for_channel 99
+set zerowidth_tchannel True
+set nlo_mixed_expansion True
+import model sm
+
+set auto_convert_model T
+import model --modelname HAHM_variableMW_v3_UFO/
+define l+ = e+ m+
+define l- = e- m-
+define q = u c d s b
+define q~ = u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt-
+
+#*** generate the process: e+ e- -> Z -> Z h with Z -> q q~ and h -> 2hs -> 4b
+generate e+ e- > z > z h, z > q q~, (h > hs hs, hs > b b~)
+
+output h_2hs_4b_mhs60GeV_WHSe-13_H
+
+# launch the event generation
+launch
+
+#*** set electron beams and the center-of-mass energy to the ZH maximum production peak (240 GeV), i.e 120 GeV per electron beam
+
+# set beam type; 0 for electron, 1 for proton	
+set lpp1 0
+set lpp2 0
+# set total energy in GeV for each beam 
+set ebeam1 120		
+set ebeam2 120
+
+#*** set model parameters; couplings and masses
+
+# the model accounts both dark scalars and dark photons, hence set the kinetic mixing coupling epsilon to zero and mass of dark photon high (to only simulate SM + dark scalar singlet)
+set epsilon 1.000000e-10
+set mZDinput 1.000000e+03
+
+# set the mass of the dark scalar
+set MHSinput 60.000000e+00
+
+# set singlet-higgs coupling
+set kap 7.000000e-04
+
+# set the decay width to O(e-13) s.t sin^2 theta = O(e-10) and decay length O(mm)
+set whs 2.251767e-13
+
+# set the width of the higgs and the dark photon to auto
+set wh Auto
+set wzp Auto
+
+# needed to get llp
+set time_of_flight 0
+
+# set number of events
+set nevents 10000
+
+done

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS60GeV_WHSe-13_proc_card_NU.dat
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS60GeV_WHSe-13_proc_card_NU.dat
@@ -1,0 +1,88 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 3.4.1                 2022-09-01         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set low_mem_multicore_nlo_generation False
+set complex_mass_scheme False
+set include_lepton_initiated_processes False
+set gauge unitary
+set loop_optimized_output True
+set loop_color_flows False
+set max_npoint_for_channel 0
+set default_unset_couplings 99
+set max_t_for_channel 99
+set zerowidth_tchannel True
+set nlo_mixed_expansion True
+import model sm
+
+set auto_convert_model T
+import model --modelname HAHM_variableMW_v3_UFO/
+define l+ = e+ m+
+define l- = e- m-
+define q = u c d s b
+define q~ = u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt-
+
+#*** generate the process: e+ e- -> Z -> Z h with Z -> q q~ and h -> 2hs -> 4b
+generate e+ e- > z > z h, z > vl vl~, (h > hs hs, hs > b b~)
+
+output h_2hs_4b_mhs60GeV_WHSe-13_NU
+
+# launch the event generation
+launch
+
+#*** set electron beams and the center-of-mass energy to the ZH maximum production peak (240 GeV), i.e 120 GeV per electron beam
+
+# set beam type; 0 for electron, 1 for proton	
+set lpp1 0
+set lpp2 0
+# set total energy in GeV for each beam 
+set ebeam1 120		
+set ebeam2 120
+
+#*** set model parameters; couplings and masses
+
+# the model accounts both dark scalars and dark photons, hence set the kinetic mixing coupling epsilon to zero and mass of dark photon high (to only simulate SM + dark scalar singlet)
+set epsilon 1.000000e-10
+set mZDinput 1.000000e+03
+
+# set the mass of the dark scalar
+set MHSinput 60.000000e+00
+
+# set singlet-higgs coupling
+set kap 7.000000e-04
+
+# set the decay width to O(e-13) s.t sin^2 theta = O(e-10) and decay length O(mm)
+set whs 2.251767e-13
+
+# set the width of the higgs and the dark photon to auto
+set wh Auto
+set wzp Auto
+
+# needed to get llp
+set time_of_flight 0
+
+# set number of events
+set nevents 10000
+
+done

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS60GeV_WHSe-15_proc_card_H.dat
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS60GeV_WHSe-15_proc_card_H.dat
@@ -1,0 +1,88 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 3.4.1                 2022-09-01         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set low_mem_multicore_nlo_generation False
+set complex_mass_scheme False
+set include_lepton_initiated_processes False
+set gauge unitary
+set loop_optimized_output True
+set loop_color_flows False
+set max_npoint_for_channel 0
+set default_unset_couplings 99
+set max_t_for_channel 99
+set zerowidth_tchannel True
+set nlo_mixed_expansion True
+import model sm
+
+set auto_convert_model T
+import model --modelname HAHM_variableMW_v3_UFO/
+define l+ = e+ m+
+define l- = e- m-
+define q = u c d s b
+define q~ = u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt-
+
+#*** generate the process: e+ e- -> Z -> Z h with Z -> q q~ and h -> 2hs -> 4b
+generate e+ e- > z > z h, z > q q~, (h > hs hs, hs > b b~)
+
+output h_2hs_4b_mhs60GeV_WHSe-15_H
+
+# launch the event generation
+launch
+
+#*** set electron beams and the center-of-mass energy to the ZH maximum production peak (240 GeV), i.e 120 GeV per electron beam
+
+# set beam type; 0 for electron, 1 for proton	
+set lpp1 0
+set lpp2 0
+# set total energy in GeV for each beam 
+set ebeam1 120		
+set ebeam2 120
+
+#*** set model parameters; couplings and masses
+
+# the model accounts both dark scalars and dark photons, hence set the kinetic mixing coupling epsilon to zero and mass of dark photon high (to only simulate SM + dark scalar singlet)
+set epsilon 1.000000e-10
+set mZDinput 1.000000e+03
+
+# set the mass of the dark scalar
+set MHSinput 60.000000e+00
+
+# set singlet-higgs coupling
+set kap 7.000000e-04
+
+# set the decay width to O(e-15) s.t sin^2 theta = O(e-12) and decay length O(100 mm)
+set whs 2.251767e-15
+
+# set the width of the higgs and the dark photon to auto
+set wh Auto
+set wzp Auto
+
+# needed to get llp
+set time_of_flight 0
+
+# set number of events
+set nevents 10000
+
+done

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS60GeV_WHSe-15_proc_card_NU.dat
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS60GeV_WHSe-15_proc_card_NU.dat
@@ -1,0 +1,88 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 3.4.1                 2022-09-01         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set low_mem_multicore_nlo_generation False
+set complex_mass_scheme False
+set include_lepton_initiated_processes False
+set gauge unitary
+set loop_optimized_output True
+set loop_color_flows False
+set max_npoint_for_channel 0
+set default_unset_couplings 99
+set max_t_for_channel 99
+set zerowidth_tchannel True
+set nlo_mixed_expansion True
+import model sm
+
+set auto_convert_model T
+import model --modelname HAHM_variableMW_v3_UFO/
+define l+ = e+ m+
+define l- = e- m-
+define q = u c d s b
+define q~ = u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt-
+
+#*** generate the process: e+ e- -> Z -> Z h with Z -> q q~ and h -> 2hs -> 4b
+generate e+ e- > z > z h, z > vl vl~, (h > hs hs, hs > b b~)
+
+output h_2hs_4b_mhs60GeV_WHSe-15_NU
+
+# launch the event generation
+launch
+
+#*** set electron beams and the center-of-mass energy to the ZH maximum production peak (240 GeV), i.e 120 GeV per electron beam
+
+# set beam type; 0 for electron, 1 for proton	
+set lpp1 0
+set lpp2 0
+# set total energy in GeV for each beam 
+set ebeam1 120		
+set ebeam2 120
+
+#*** set model parameters; couplings and masses
+
+# the model accounts both dark scalars and dark photons, hence set the kinetic mixing coupling epsilon to zero and mass of dark photon high (to only simulate SM + dark scalar singlet)
+set epsilon 1.000000e-10
+set mZDinput 1.000000e+03
+
+# set the mass of the dark scalar
+set MHSinput 60.000000e+00
+
+# set singlet-higgs coupling
+set kap 7.000000e-04
+
+# set the decay width to O(e-15) s.t sin^2 theta = O(e-12) and decay length O(100 mm)
+set whs 2.251767e-15
+
+# set the width of the higgs and the dark photon to auto
+set wh Auto
+set wzp Auto
+
+# needed to get llp
+set time_of_flight 0
+
+# set number of events
+set nevents 10000
+
+done

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS60GeV_WHSe-17_proc_card_H.dat
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS60GeV_WHSe-17_proc_card_H.dat
@@ -1,0 +1,88 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 3.4.1                 2022-09-01         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set low_mem_multicore_nlo_generation False
+set complex_mass_scheme False
+set include_lepton_initiated_processes False
+set gauge unitary
+set loop_optimized_output True
+set loop_color_flows False
+set max_npoint_for_channel 0
+set default_unset_couplings 99
+set max_t_for_channel 99
+set zerowidth_tchannel True
+set nlo_mixed_expansion True
+import model sm
+
+set auto_convert_model T
+import model --modelname HAHM_variableMW_v3_UFO/
+define l+ = e+ m+
+define l- = e- m-
+define q = u c d s b
+define q~ = u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt-
+
+#*** generate the process: e+ e- -> Z -> Z h with Z -> q q~ and h -> 2hs -> 4b
+generate e+ e- > z > z h, z > q q~, (h > hs hs, hs > b b~)
+
+output h_2hs_4b_mhs60GeV_WHSe-17_H
+
+# launch the event generation
+launch
+
+#*** set electron beams and the center-of-mass energy to the ZH maximum production peak (240 GeV), i.e 120 GeV per electron beam
+
+# set beam type; 0 for electron, 1 for proton	
+set lpp1 0
+set lpp2 0
+# set total energy in GeV for each beam 
+set ebeam1 120		
+set ebeam2 120
+
+#*** set model parameters; couplings and masses
+
+# the model accounts both dark scalars and dark photons, hence set the kinetic mixing coupling epsilon to zero and mass of dark photon high (to only simulate SM + dark scalar singlet)
+set epsilon 1.000000e-10
+set mZDinput 1.000000e+03
+
+# set the mass of the dark scalar
+set MHSinput 60.000000e+00
+
+# set singlet-higgs coupling
+set kap 7.000000e-04
+
+# set the decay width to O(e-17) s.t sin^2 theta = O(e-14) and decay length O(10 m)
+set whs 2.251767e-17
+
+# set the width of the higgs and the dark photon to auto
+set wh Auto
+set wzp Auto
+
+# needed to get llp
+set time_of_flight 0
+
+# set number of events
+set nevents 10000
+
+done

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS60GeV_WHSe-17_proc_card_NU.dat
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/H_ss_4b_SampleGeneration/exoticHiggs_scalar_mS60GeV_WHSe-17_proc_card_NU.dat
@@ -1,0 +1,88 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 3.4.1                 2022-09-01         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set low_mem_multicore_nlo_generation False
+set complex_mass_scheme False
+set include_lepton_initiated_processes False
+set gauge unitary
+set loop_optimized_output True
+set loop_color_flows False
+set max_npoint_for_channel 0
+set default_unset_couplings 99
+set max_t_for_channel 99
+set zerowidth_tchannel True
+set nlo_mixed_expansion True
+import model sm
+
+set auto_convert_model T
+import model --modelname HAHM_variableMW_v3_UFO/
+define l+ = e+ m+
+define l- = e- m-
+define q = u c d s b
+define q~ = u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt-
+
+#*** generate the process: e+ e- -> Z -> Z h with Z -> q q~ and h -> 2hs -> 4b
+generate e+ e- > z > z h, z > vl vl~, (h > hs hs, hs > b b~)
+
+output h_2hs_4b_mhs60GeV_WHSe-17_NU
+
+# launch the event generation
+launch
+
+#*** set electron beams and the center-of-mass energy to the ZH maximum production peak (240 GeV), i.e 120 GeV per electron beam
+
+# set beam type; 0 for electron, 1 for proton	
+set lpp1 0
+set lpp2 0
+# set total energy in GeV for each beam 
+set ebeam1 120		
+set ebeam2 120
+
+#*** set model parameters; couplings and masses
+
+# the model accounts both dark scalars and dark photons, hence set the kinetic mixing coupling epsilon to zero and mass of dark photon high (to only simulate SM + dark scalar singlet)
+set epsilon 1.000000e-10
+set mZDinput 1.000000e+03
+
+# set the mass of the dark scalar
+set MHSinput 60.000000e+00
+
+# set singlet-higgs coupling
+set kap 7.000000e-04
+
+# set the decay width to O(e-17) s.t sin^2 theta = O(e-14) and decay length O(10 m)
+set whs 2.251767e-17
+
+# set the width of the higgs and the dark photon to auto
+set wh Auto
+set wzp Auto
+
+# needed to get llp
+set time_of_flight 0
+
+# set number of events
+set nevents 10000
+
+done

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_final.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_final.py
@@ -1,10 +1,11 @@
 #Input directory where the files produced at the stage1 level are
 #inputDir  = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/MC_output_stage1/"
 inputDir = "MC_output_stage1/"
+#inputDir = "MC_output_stage1_CLD/"
 
 #Output directory where the files produced at the final-selection level are
 outputDir  = "MC_output_finalSel/"
-
+#outputDir  = "MC_output_finalSel_CLD/"
 #Integrated luminosity for scaling number of events (required only if setting doScale to true)
 #intLumi = 5e6 #pb^-1
 
@@ -24,6 +25,12 @@ processList = {
         # 'exoticHiggs_scalar_ms60GeV_sine-5':{},
         # 'exoticHiggs_scalar_ms60GeV_sine-6':{},
         # 'exoticHiggs_scalar_ms60GeV_sine-7':{},
+        # 'exoticHiggs_scalar_ms20GeV_sine-5_CLD':{},
+        # 'exoticHiggs_scalar_ms20GeV_sine-6_CLD':{},
+        # 'exoticHiggs_scalar_ms20GeV_sine-7_CLD':{},
+        # 'exoticHiggs_scalar_ms60GeV_sine-5_CLD':{},
+        # 'exoticHiggs_scalar_ms60GeV_sine-6_CLD':{},
+        # 'exoticHiggs_scalar_ms60GeV_sine-7_CLD':{},
 
 }
 
@@ -36,10 +43,17 @@ processLabels = {
     'exoticHiggs_scalar_ms60GeV_sine-5': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-5}$",
     'exoticHiggs_scalar_ms60GeV_sine-6': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-6}$",
     'exoticHiggs_scalar_ms60GeV_sine-7': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-7}$",
+    #'exoticHiggs_scalar_ms20GeV_sine-5_CLD': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-5}$",
+    #'exoticHiggs_scalar_ms20GeV_sine-6_CLD': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-6}$",
+    #'exoticHiggs_scalar_ms20GeV_sine-7_CLD': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-7}$",
+    #'exoticHiggs_scalar_ms60GeV_sine-5_CLD': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-5}$",
+    #'exoticHiggs_scalar_ms60GeV_sine-6_CLD': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-6}$",
+    #'exoticHiggs_scalar_ms60GeV_sine-7_CLD': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-7}$",
 }
 
 #Link to the dictonary that contains all the cross section information etc...
 procDict = "FCCee_procDict_spring2021_IDEA.json"
+#procDict = "FCCee_procDict_spring2021_IDEA_FullSilicon.json" 
 
 #Add MySample_p8_ee_ZH_ecm240 as it is not an offical process
 procDictAdd={
@@ -49,6 +63,12 @@ procDictAdd={
     'exoticHiggs_scalar_ms60GeV_sine-5': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 1.311e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
     'exoticHiggs_scalar_ms60GeV_sine-6': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 1.311e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
     'exoticHiggs_scalar_ms60GeV_sine-7': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 1.311e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    #'exoticHiggs_scalar_ms20GeV_sine-5_CLD': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 4.434e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    #'exoticHiggs_scalar_ms20GeV_sine-6_CLD': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 4.434e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    #'exoticHiggs_scalar_ms20GeV_sine-7_CLD': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 4.434e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    #'exoticHiggs_scalar_ms60GeV_sine-5_CLD': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 1.311e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    #'exoticHiggs_scalar_ms60GeV_sine-6_CLD': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 1.311e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    #'exoticHiggs_scalar_ms60GeV_sine-7_CLD': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 1.311e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
 }
 
 #Number of CPUs to use

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_final_H.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_final_H.py
@@ -1,0 +1,119 @@
+#Input directory where the files produced at the stage1 level are
+#inputDir  = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/MC_output_stage1/"
+inputDir = "MC_output_stage1_H"
+
+#Output directory where the files produced at the final-selection level are
+outputDir  = "MC_output_finalSel_H/"
+
+#Integrated luminosity for scaling number of events (required only if setting doScale to true)
+#intLumi = 5e6 #pb^-1
+
+#Scale event yields by intLumi and cross section (optional)
+#doScale = True
+
+#Save event yields in a table (optional)
+#saveTabular = True
+
+#Mandatory: List of processes
+processList = {
+
+        #privately-produced signals
+        'exoticHiggs_scalar_ms20GeV_sine-5_H':{},
+        'exoticHiggs_scalar_ms20GeV_sine-6_H':{},
+        'exoticHiggs_scalar_ms20GeV_sine-7_H':{},
+        'exoticHiggs_scalar_ms60GeV_sine-5_H':{},
+        'exoticHiggs_scalar_ms60GeV_sine-6_H':{},
+        'exoticHiggs_scalar_ms60GeV_sine-7_H':{},
+
+        # #centrally produced backgrounds
+        'p8_ee_ZZ_ecm240':{'fraction':0.005, 'chunks':5},   
+        'p8_ee_WW_ecm240':{'fraction':0.005, 'chunks':5},   
+        'wzp6_ee_ccH_HWW_ecm240':{'fraction':0.005, 'chunks':5},   
+        'wzp6_ee_qqH_HWW_ecm240':{'fraction':0.005, 'chunks':5},   
+        'wzp6_ee_bbH_HWW_ecm240':{'fraction':0.005, 'chunks':5},   
+        'wzp6_ee_ssH_HWW_ecm240':{'fraction':0.005, 'chunks':5},   
+        'wzp6_ee_ssH_Hbb_ecm240':{'fraction':0.005, 'chunks':5},   
+        'wzp6_ee_qqH_Hbb_ecm240':{'fraction':0.005, 'chunks':5},   
+        'wzp6_ee_bbH_Hbb_ecm240':{'fraction':0.005, 'chunks':5},   
+        'wzp6_ee_ccH_Hbb_ecm240':{'fraction':0.005, 'chunks':5} 
+
+}
+
+###Dictionary for prettier names of processes (optional)
+processLabels = {
+    #signals
+    'exoticHiggs_scalar_ms20GeV_sine-5_H': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-5}$",
+    'exoticHiggs_scalar_ms20GeV_sine-6_H': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-6}$",
+    'exoticHiggs_scalar_ms20GeV_sine-7_H': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-7}$",
+    'exoticHiggs_scalar_ms60GeV_sine-5_H': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-5}$",
+    'exoticHiggs_scalar_ms60GeV_sine-6_H': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-6}$",
+    'exoticHiggs_scalar_ms60GeV_sine-7_H': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-7}$",
+
+    # #backgrounds
+    'p8_ee_WW_ecm240': "e^{-}e^{+} $\rightarrow$ WW",
+    'p8_ee_ZZ_ecm240': "e^{-}e^{+} $\rightarrow$ ZZ",
+    'p8_ee_ZH_ecm240': "e^{-}e^{+} $\rightarrow$ ZH",
+    'p8_ee_ZZ_ecm240': "e^{-}e^{+} $\rightarrow$ WW",
+    'p8_ee_WW_ecm240': "e^{-}e^{+} $\rightarrow$ ZZ",
+    'wzp6_ee_ccH_HWW_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ cc, H $\rightarrow$ WW",
+    'wzp6_ee_qqH_HWW_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ 1/2(uu + dd), H $\rightarrow$ WW",
+    'wzp6_ee_bbH_HWW_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ bb, H $\rightarrow$ WW",
+    'wzp6_ee_ssH_HWW_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ ss, H $\rightarrow$ WW",
+    'wzp6_ee_ssH_Hbb_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ ss, H $\rightarrow$ bb",
+    'wzp6_ee_qqH_Hbb_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ 1/2(uu + dd), H $\rightarrow$ bb",
+    'wzp6_ee_bbH_Hbb_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ bb, H $\rightarrow$ bb",
+    'wzp6_ee_ccH_Hbb_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ cc, H $\rightarrow$ bb"
+}
+
+#Link to the dictonary that contains all the cross section information etc...
+procDict = "FCCee_procDict_winter2023_IDEA.json"
+
+#Add MySample_p8_ee_ZH_ecm240 as it is not an offical process
+procDictAdd={
+    'exoticHiggs_scalar_ms20GeV_sine-5_H': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 1.5943e-4, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms20GeV_sine-6_H': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 1.5943e-4, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms20GeV_sine-7_H': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 1.5943e-4, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms60GeV_sine-5_H': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 4.7134e-5, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms60GeV_sine-6_H': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 4.7134e-5, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms60GeV_sine-7_H': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 4.7134e-5, "kfactor": 1.0, "matchingEfficiency": 1.0}
+}
+
+#Number of CPUs to use
+nCPUS = 2
+
+#produces ROOT TTrees, default is False
+doTree = False
+
+###Dictionnay of the list of cuts. The key is the name of the selection that will be added to the output file
+cutList = {
+    "selNone": "n_GenZ > -1",
+    
+}
+
+###Dictionary for prettier names of cuts (optional)
+cutLabels = {
+    "selNone": "Before selection",
+}
+
+###Dictionary for the ouput variable/hitograms. The key is the name of the variable in the output files. "name" is the name of the variable in the input file, "title" is the x-axis label of the histogram, "bin" the number of bins of the histogram, "xmin" the minimum x-axis value and "xmax" the maximum x-axis value.
+histoList = {
+
+    #gen variables
+    'n_GenU':                           {"name":"n_GenU",                         "title":"Number of generated up quarks",        "bin":20,"xmin":-0.5 ,"xmax":20.5},
+    'n_GenD':                           {"name":"n_GenD",                         "title":"Number of generated down quarks",            "bin":20,"xmin":-0.5 ,"xmax":20.5},
+    'n_GenC':                           {"name":"n_GenC",                         "title":"Number of generated charm quarks",        "bin":20,"xmin":-0.5 ,"xmax":20.5},
+    'n_GenS':                           {"name":"n_GenS",                         "title":"Number of generated strange quarks",            "bin":20,"xmin":-0.5 ,"xmax":20.5},
+    'n_GenZ':                           {"name":"n_GenZ",                         "title":"Number of generated Z bosons",         "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    'n_GenHiggs':                       {"name":"n_GenHiggs",                     "title":"Number of generated Higgs bosons",      "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    'n_Genb':                           {"name":"n_Genb",                         "title":"Number of generated b quarks",          "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    'n_GenHS':                          {"name":"n_GenHS",                        "title":"Number of generated dark scalars",      "bin":5,"xmin":-0.5 ,"xmax":4.5},
+
+    'AllGenHS_mass':                    {"name":'AllGenHS_mass',                  "title":"Generated dark scalars mass [GeV]",     "bin":50,"xmin":-0.5 ,"xmax":49.5},
+    'AllGenHS_e':                       {"name":'AllGenHS_e',                     "title":"Generated dark scalars energy [GeV]",   "bin":100,"xmin":-0.5 ,"xmax":99.5},
+
+    'LxyHS':                            {"name":'LxyHS',                         "title":"Genenrated transverse decay length [mm]",       "bin":100,"xmin":0 ,"xmax":1000},
+    'decayLengthsHS':                   {"name":'decayLengthsHS',                "title":"Generated decay length [mm]",                   "bin":100,"xmin":0 ,"xmax":10000},
+    'lifetimeHS':                       {"name":'lifetimeHS',                    "title":"Generated time distribution t [ns]",            "bin":100,"xmin":0 ,"xmax":20},
+    'lifetimeHSLAB':                    {"name":'lifetimeHSLAB',                "title":"Generated time distribution in LAB frame [ns]", "bin":100,"xmin":0 ,"xmax":20},
+
+}

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_final_NU.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_final_NU.py
@@ -1,0 +1,103 @@
+#Input directory where the files produced at the stage1 level are
+#inputDir  = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/MC_output_stage1/"
+inputDir = "MC_output_stage1_NU"
+
+#Output directory where the files produced at the final-selection level are
+outputDir  = "MC_output_finalSel_NU/"
+
+#Integrated luminosity for scaling number of events (required only if setting doScale to true)
+#intLumi = 5e6 #pb^-1
+
+#Scale event yields by intLumi and cross section (optional)
+#doScale = True
+
+#Save event yields in a table (optional)
+#saveTabular = True
+
+#Mandatory: List of processes
+processList = {
+
+    #privately-produced signals
+    'exoticHiggs_scalar_ms20GeV_sine-5_NU':{},
+    'exoticHiggs_scalar_ms20GeV_sine-6_NU':{},
+    'exoticHiggs_scalar_ms20GeV_sine-7_NU':{},
+    'exoticHiggs_scalar_ms60GeV_sine-5_NU':{},
+    'exoticHiggs_scalar_ms60GeV_sine-6_NU':{},
+    'exoticHiggs_scalar_ms60GeV_sine-7_NU':{},
+
+    # #centrally produced backgrounds
+    'p8_ee_ZZ_ecm240':{'fraction':0.005, 'chunks':5},   
+    'p8_ee_WW_ecm240':{'fraction':0.005, 'chunks':5},     
+    'wzp6_ee_nunuH_Hbb_ecm240':{'fraction':0.005, 'chunks':5},
+    'wzp6_ee_nunuH_HWW_ecm240':{'fraction':0.005, 'chunks':5}
+
+}
+
+###Dictionary for prettier names of processes (optional)
+processLabels = {
+    #signals
+    'exoticHiggs_scalar_ms20GeV_sine-5_NU': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-5}$",
+    'exoticHiggs_scalar_ms20GeV_sine-6_NU': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-6}$",
+    'exoticHiggs_scalar_ms20GeV_sine-7_NU': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-7}$",
+    'exoticHiggs_scalar_ms60GeV_sine-5_NU': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-5}$",
+    'exoticHiggs_scalar_ms60GeV_sine-6_NU': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-6}$",
+    'exoticHiggs_scalar_ms60GeV_sine-7_NU': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-7}$",
+
+    # backgrounds
+    'p8_ee_WW_ecm240': "e^{-}e^{+} $\rightarrow$ WW",
+    'p8_ee_ZZ_ecm240': "e^{-}e^{+} $\rightarrow$ ZZ",
+    'wzp6_ee_nunuH_Hbb_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ nu nu, H $\rightarrow$ bb",
+    'wzp6_ee_nunuH_HWW_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ nu nu, H $\rightarrow$ WW",
+}
+
+#Link to the dictonary that contains all the cross section information etc...
+procDict = "FCCee_procDict_winter2023_IDEA.json"
+
+#Add MySample_p8_ee_ZH_ecm240 as it is not an offical process
+procDictAdd={
+    'exoticHiggs_scalar_ms20GeV_sine-5_NU': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 2.2797e-5, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms20GeV_sine-6_NU': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 2.2797e-5, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms20GeV_sine-7_NU': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 2.2797e-5, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms60GeV_sine-5_NU': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 6.7396e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms60GeV_sine-6_NU': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 6.7396e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms60GeV_sine-7_NU': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 6.7396e-6, "kfactor": 1.0, "matchingEfficiency": 1.0}
+}
+
+#Number of CPUs to use
+nCPUS = 2
+
+#produces ROOT TTrees, default is False
+doTree = False
+
+###Dictionnay of the list of cuts. The key is the name of the selection that will be added to the output file
+cutList = {
+    "selNone": "n_GenZ > -1",
+    
+}
+
+###Dictionary for prettier names of cuts (optional)
+cutLabels = {
+    "selNone": "Before selection",
+}
+
+###Dictionary for the ouput variable/hitograms. The key is the name of the variable in the output files. "name" is the name of the variable in the input file, "title" is the x-axis label of the histogram, "bin" the number of bins of the histogram, "xmin" the minimum x-axis value and "xmax" the maximum x-axis value.
+histoList = {
+
+    #gen variables
+    'n_GenElecNeutrinos':               {"name":"n_GenElecNeutrinos",             "title":"Number of generated electron neutrinos",        "bin":6,"xmin":-0.5 ,"xmax":5.5},
+    'n_GenMuNeutrinos':                 {"name":"n_GenMuNeutrinos",               "title":"Number of generated muon neutrinos",            "bin":6,"xmin":-0.5 ,"xmax":5.5},
+    'n_GenTauNeutrinos':                {"name":"n_GenTauNeutrinos",              "title":"Number of generated tau neutrinos",            "bin":6,"xmin":-0.5 ,"xmax":5.5},
+    'n_GenZ':                           {"name":"n_GenZ",                         "title":"Number of generated Z bosons",         "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    'n_GenHiggs':                       {"name":"n_GenHiggs",                     "title":"Number of generated Higgs bosons",      "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    'n_Genb':                           {"name":"n_Genb",                         "title":"Number of generated b quarks",          "bin":5,"xmin":-0.5 ,"xmax":4.5},
+    'n_GenHS':                          {"name":"n_GenHS",                        "title":"Number of generated dark scalars",      "bin":5,"xmin":-0.5 ,"xmax":4.5},
+
+    'AllGenHS_mass':                    {"name":'AllGenHS_mass',                  "title":"Generated dark scalars mass [GeV]",     "bin":50,"xmin":-0.5 ,"xmax":49.5},
+    'AllGenHS_e':                       {"name":'AllGenHS_e',                     "title":"Generated dark scalars energy [GeV]",   "bin":100,"xmin":-0.5 ,"xmax":99.5},
+
+    'LxyHS':                            {"name":'LxyHS',                         "title":"Genenrated transverse decay length [mm]",       "bin":100,"xmin":0 ,"xmax":1000},
+    'decayLengthsHS':                   {"name":'decayLengthsHS',                "title":"Generated decay length [mm]",                   "bin":100,"xmin":0 ,"xmax":10000},
+    'lifetimeHS':                       {"name":'lifetimeHS',                    "title":"Generated time distribution t [ns]",            "bin":100,"xmin":0 ,"xmax":20},
+    'lifetimeHSLAB':                    {"name":'lifetimeHSLAB',                "title":"Generated time distribution in LAB frame [ns]", "bin":100,"xmin":0 ,"xmax":20},
+
+}

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_plots.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_plots.py
@@ -12,11 +12,13 @@ delphesVersion = '3.4.2'
 energy         = 240
 collider       = 'FCC-ee'
 inputDir       = 'MC_output_finalSel/'
+#inputDir       = 'MC_output_finalSec_CLD/'
 #formats        = ['png','pdf']
 formats        = ['pdf']
 yaxis          = ['lin','log']
 stacksig       = ['nostack']
 outdir         = 'MC_plots/'
+#outdir         = 'MC_plots_CLD/'
 splitLeg       = True
 
 variables = [
@@ -55,6 +57,13 @@ colors['exoticHiggs_scalar_ms60GeV_sine-5'] = ROOT.kGreen+1
 colors['exoticHiggs_scalar_ms60GeV_sine-6'] = ROOT.kCyan-9
 colors['exoticHiggs_scalar_ms60GeV_sine-7'] = ROOT.kViolet-4
 
+#colors['exoticHiggs_scalar_ms20GeV_sine-5_CLD'] = ROOT.kOrange+1
+#colors['exoticHiggs_scalar_ms20GeV_sine-6_CLD'] = ROOT.kRed
+#colors['exoticHiggs_scalar_ms20GeV_sine-7_CLD'] = ROOT.kBlue
+#colors['exoticHiggs_scalar_ms60GeV_sine-5_CLD'] = ROOT.kGreen+1
+#colors['exoticHiggs_scalar_ms60GeV_sine-6_CLD'] = ROOT.kCyan-9
+#colors['exoticHiggs_scalar_ms60GeV_sine-7_CLD'] = ROOT.kViolet-4
+
 plots = {}
 plots['ExoticHiggs'] = {'signal':{
                     'exoticHiggs_scalar_ms20GeV_sine-5':['exoticHiggs_scalar_ms20GeV_sine-5'],
@@ -63,6 +72,12 @@ plots['ExoticHiggs'] = {'signal':{
                     'exoticHiggs_scalar_ms60GeV_sine-5':['exoticHiggs_scalar_ms60GeV_sine-5'],
                     'exoticHiggs_scalar_ms60GeV_sine-6':['exoticHiggs_scalar_ms60GeV_sine-6'],
                     'exoticHiggs_scalar_ms60GeV_sine-7':['exoticHiggs_scalar_ms60GeV_sine-7'],
+                    #'exoticHiggs_scalar_ms20GeV_sine-5_CLD':['exoticHiggs_scalar_ms20GeV_sine-5_CLD'],
+                    #'exoticHiggs_scalar_ms20GeV_sine-6_CLD':['exoticHiggs_scalar_ms20GeV_sine-6_CLD'],
+                    #'exoticHiggs_scalar_ms20GeV_sine-7_CLD':['exoticHiggs_scalar_ms20GeV_sine-7_CLD'],
+                    #'exoticHiggs_scalar_ms60GeV_sine-5_CLD':['exoticHiggs_scalar_ms60GeV_sine-5_CLD'],
+                    #'exoticHiggs_scalar_ms60GeV_sine-6_CLD':['exoticHiggs_scalar_ms60GeV_sine-6_CLD'],
+                    #'exoticHiggs_scalar_ms60GeV_sine-7_CLD':['exoticHiggs_scalar_ms60GeV_sine-7_CLD'],
 },
 'backgrounds':{
             #
@@ -77,3 +92,10 @@ legend['exoticHiggs_scalar_ms20GeV_sine-7'] = 'm_{S} = 20 GeV, sin #theta = 1e-7
 legend['exoticHiggs_scalar_ms60GeV_sine-5'] = 'm_{S} = 60 GeV, sin #theta = 1e-5'
 legend['exoticHiggs_scalar_ms60GeV_sine-6'] = 'm_{S} = 60 GeV, sin #theta = 1e-6'
 legend['exoticHiggs_scalar_ms60GeV_sine-7'] = 'm_{S} = 60 GeV, sin #theta = 1e-7'
+
+#legend['exoticHiggs_scalar_ms20GeV_sine-5_CLD'] = 'm_{S} = 20 GeV, sin #theta = 1e-5'
+#legend['exoticHiggs_scalar_ms20GeV_sine-6_CLD'] = 'm_{S} = 20 GeV, sin #theta = 1e-6'
+#legend['exoticHiggs_scalar_ms20GeV_sine-7_CLD'] = 'm_{S} = 20 GeV, sin #theta = 1e-7'
+#legend['exoticHiggs_scalar_ms60GeV_sine-5_CLD'] = 'm_{S} = 60 GeV, sin #theta = 1e-5'
+#legend['exoticHiggs_scalar_ms60GeV_sine-6_CLD'] = 'm_{S} = 60 GeV, sin #theta = 1e-6'
+#legend['exoticHiggs_scalar_ms60GeV_sine-7_CLD'] = 'm_{S} = 60 GeV, sin #theta = 1e-7'

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_plots_H.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_plots_H.py
@@ -1,0 +1,112 @@
+import ROOT
+
+# global parameters
+intLumi        = 5.0e+06 #in pb-1
+
+###If scaleSig=0 or scaleBack=0, we don't apply any additional scaling, on top of the normalization to cross section and integrated luminosity, as defined in finalSel.py
+###If scaleSig or scaleBack is not defined, plots will be normalized to 1
+#scaleSig       = 0.
+#scaleBack      = 0.
+ana_tex        = 'e^{+}e^{-} #rightarrow Z h, Z #rightarrow q^{+}q^{-}, h #rightarrow ss #rightarrow b #bar{b} b #bar{b}'
+delphesVersion = '3.4.2'
+energy         = 240
+collider       = 'FCC-ee'
+inputDir       = 'MC_output_finalSel_H/'
+#formats        = ['png','pdf']
+formats        = ['pdf']
+yaxis          = ['lin','log']
+stacksig       = ['nostack']
+outdir         = 'MC_plots_H/'
+splitLeg       = True
+
+variables = [
+
+    #gen variables
+    'n_GenU',
+    'n_GenD',
+    'n_GenC',
+    'n_GenS',
+    'n_GenZ',
+    'n_GenHiggs',
+    'n_Genb',
+    'n_GenHS',
+    'AllGenHS_mass',
+    'AllGenHS_e',
+    'decayLengthsHS',
+    'LxyHS',
+    'lifetimeHS',
+    'lifetimeHSLAB',
+    
+             ]
+
+    
+###Dictionary with the analysis name as a key, and the list of selections to be plotted for this analysis. The name of the selections should be the same than in the final selection
+selections = {}
+selections['ExoticHiggs']  = [
+    "selNone",
+]
+
+extralabel = {}
+extralabel['selNone'] = "Before selection"
+
+colors = {}
+colors['exoticHiggs_scalar_ms20GeV_sine-5_H'] = ROOT.kOrange+1
+colors['exoticHiggs_scalar_ms20GeV_sine-6_H'] = ROOT.kRed
+colors['exoticHiggs_scalar_ms20GeV_sine-7_H'] = ROOT.kBlue
+colors['exoticHiggs_scalar_ms60GeV_sine-5_H'] = ROOT.kGreen+1
+colors['exoticHiggs_scalar_ms60GeV_sine-6_H'] = ROOT.kCyan-9
+colors['exoticHiggs_scalar_ms60GeV_sine-7_H'] = ROOT.kViolet-4
+
+colors['p8_ee_ZZ_ecm240'] = ROOT.kAzure
+colors['p8_ee_WW_ecm240'] = ROOT.kCyan
+colors['wzp6_ee_ccH_HWW_ecm240'] = ROOT.kGray
+colors['wzp6_ee_qqH_HWW_ecm240'] = ROOT.kRed-4
+colors['wzp6_ee_bbH_HWW_ecm240'] = ROOT.kBlue-5
+colors['wzp6_ee_ssH_HWW_ecm240'] = ROOT.kCyan+8
+colors['wzp6_ee_ssH_Hbb_ecm240'] = ROOT.kGreen+4
+colors['wzp6_ee_qqH_Hbb_ecm240'] = ROOT.kSpring+8
+colors['wzp6_ee_bbH_Hbb_ecm240'] = ROOT.kYellow-5
+colors['wzp6_ee_ccH_Hbb_ecm240'] = ROOT.kOrange+9
+
+plots = {}
+plots['ExoticHiggs'] = {'signal':{
+                    'exoticHiggs_scalar_ms20GeV_sine-5_H':['exoticHiggs_scalar_ms20GeV_sine-5_H'],
+                    'exoticHiggs_scalar_ms20GeV_sine-6_H':['exoticHiggs_scalar_ms20GeV_sine-6_H'],
+                    'exoticHiggs_scalar_ms20GeV_sine-7_H':['exoticHiggs_scalar_ms20GeV_sine-7_H'],
+                    'exoticHiggs_scalar_ms60GeV_sine-5_H':['exoticHiggs_scalar_ms60GeV_sine-5_H'],
+                    'exoticHiggs_scalar_ms60GeV_sine-6_H':['exoticHiggs_scalar_ms60GeV_sine-6_H'],
+                    'exoticHiggs_scalar_ms60GeV_sine-7_H':['exoticHiggs_scalar_ms60GeV_sine-7_H'],
+},
+'backgrounds':{
+            'p8_ee_ZZ_ecm240':['p8_ee_ZZ_ecm240'],
+            'p8_ee_WW_ecm240':['p8_ee_WW_ecm240'],
+            'wzp6_ee_ccH_HWW_ecm240':['wzp6_ee_ccH_HWW_ecm240'],
+            'wzp6_ee_qqH_HWW_ecm240':['wzp6_ee_qqH_HWW_ecm240'],
+            'wzp6_ee_bbH_HWW_ecm240':['wzp6_ee_bbH_HWW_ecm240'],
+            'wzp6_ee_ssH_HWW_ecm240':['wzp6_ee_ssH_HWW_ecm240'],
+            'wzp6_ee_ssH_Hbb_ecm240':['wzp6_ee_ssH_Hbb_ecm240'],
+            'wzp6_ee_qqH_Hbb_ecm240':['wzp6_ee_qqH_Hbb_ecm240'],
+            'wzp6_ee_bbH_Hbb_ecm240':['wzp6_ee_bbH_Hbb_ecm240'],
+            'wzp6_ee_ccH_Hbb_ecm240':['wzp6_ee_ccH_Hbb_ecm240']
+                }
+                }
+
+
+legend = {}
+legend['exoticHiggs_scalar_ms20GeV_sine-5_H'] = 'm_{S} = 20 GeV, sin #theta = 1e-5'
+legend['exoticHiggs_scalar_ms20GeV_sine-6_H'] = 'm_{S} = 20 GeV, sin #theta = 1e-6'
+legend['exoticHiggs_scalar_ms20GeV_sine-7_H'] = 'm_{S} = 20 GeV, sin #theta = 1e-7'
+legend['exoticHiggs_scalar_ms60GeV_sine-5_H'] = 'm_{S} = 60 GeV, sin #theta = 1e-5'
+legend['exoticHiggs_scalar_ms60GeV_sine-6_H'] = 'm_{S} = 60 GeV, sin #theta = 1e-6'
+legend['exoticHiggs_scalar_ms60GeV_sine-7_H'] = 'm_{S} = 60 GeV, sin #theta = 1e-7'
+
+legend['p8_ee_ZZ_ecm240'] = 'e^{+}e^{-} #rightarrow ZZ'
+legend['p8_ee_WW_ecm240'] = 'e^{+}e^{-} #rightarrow WW'
+legend['wzp6_ee_ccH_HWW_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ cc, H $\rightarrow$ WW'
+legend['wzp6_ee_qqH_HWW_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ 1/2(uu + dd), H $\rightarrow$ WW'
+legend['wzp6_ee_bbH_HWW_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ bb, H $\rightarrow$ WW'
+legend['wzp6_ee_ssH_HWW_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ ss, H $\rightarrow$ WW'
+legend['wzp6_ee_ssH_Hbb_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ ss, H $\rightarrow$ bb'
+legend['wzp6_ee_qqH_Hbb_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ 1/2(uu + dd), H $\rightarrow$ bb'
+legend['wzp6_ee_bbH_Hbb_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ bb, H $\rightarrow$ bb'
+legend['wzp6_ee_ccH_Hbb_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ cc, H $\rightarrow$ bb'

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_plots_NU.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_plots_NU.py
@@ -1,0 +1,93 @@
+import ROOT
+
+# global parameters
+intLumi        = 5.0e+06 #in pb-1
+
+###If scaleSig=0 or scaleBack=0, we don't apply any additional scaling, on top of the normalization to cross section and integrated luminosity, as defined in finalSel.py
+###If scaleSig or scaleBack is not defined, plots will be normalized to 1
+#scaleSig       = 0.
+#scaleBack      = 0.
+ana_tex        = 'e^{+}e^{-} #rightarrow Z h, Z #rightarrow nu nu, h #rightarrow ss #rightarrow b #bar{b} b #bar{b}'
+delphesVersion = '3.4.2'
+energy         = 240
+collider       = 'FCC-ee'
+inputDir       = 'MC_output_finalSel_NU/'
+#formats        = ['png','pdf']
+formats        = ['pdf']
+yaxis          = ['lin','log']
+stacksig       = ['nostack']
+outdir         = 'MC_plots_NU/'
+splitLeg       = True
+
+variables = [
+
+    #gen variables
+    'n_GenElecNeutrinos',
+    'n_GenMuNeutrinos',
+    'n_GenTauNeutrinos',
+    'n_GenZ',
+    'n_GenHiggs',
+    'n_Genb',
+    'n_GenHS',
+    'AllGenHS_mass',
+    'AllGenHS_e',
+    'decayLengthsHS',
+    'LxyHS',
+    'lifetimeHS',
+    'lifetimeHSLAB',
+    
+             ]
+
+    
+###Dictionary with the analysis name as a key, and the list of selections to be plotted for this analysis. The name of the selections should be the same than in the final selection
+selections = {}
+selections['ExoticHiggs']  = [
+    "selNone",
+]
+
+extralabel = {}
+extralabel['selNone'] = "Before selection"
+
+colors = {}
+colors['exoticHiggs_scalar_ms20GeV_sine-5_NU'] = ROOT.kOrange+1
+colors['exoticHiggs_scalar_ms20GeV_sine-6_NU'] = ROOT.kRed
+colors['exoticHiggs_scalar_ms20GeV_sine-7_NU'] = ROOT.kBlue
+colors['exoticHiggs_scalar_ms60GeV_sine-5_NU'] = ROOT.kGreen+1
+colors['exoticHiggs_scalar_ms60GeV_sine-6_NU'] = ROOT.kCyan-9
+colors['exoticHiggs_scalar_ms60GeV_sine-7_NU'] = ROOT.kViolet-4
+
+colors['p8_ee_WW_ecm240'] = ROOT.kAzure
+colors['p8_ee_ZZ_ecm240'] = ROOT.kCyan
+colors['wzp6_ee_nunuH_Hbb_ecm240'] = ROOT.kGray
+colors['wzp6_ee_nunuH_HWW_ecm240'] = ROOT.kRed-4
+
+plots = {}
+plots['ExoticHiggs'] = {'signal':{
+                    'exoticHiggs_scalar_ms20GeV_sine-5_NU':['exoticHiggs_scalar_ms20GeV_sine-5_NU'],
+                    'exoticHiggs_scalar_ms20GeV_sine-6_NU':['exoticHiggs_scalar_ms20GeV_sine-6_NU'],
+                    'exoticHiggs_scalar_ms20GeV_sine-7_NU':['exoticHiggs_scalar_ms20GeV_sine-7_NU'],
+                    'exoticHiggs_scalar_ms60GeV_sine-5_NU':['exoticHiggs_scalar_ms60GeV_sine-5_NU'],
+                    'exoticHiggs_scalar_ms60GeV_sine-6_NU':['exoticHiggs_scalar_ms60GeV_sine-6_NU'],
+                    'exoticHiggs_scalar_ms60GeV_sine-7_NU':['exoticHiggs_scalar_ms60GeV_sine-7_NU'],
+},
+'backgrounds':{
+            'p8_ee_WW_ecm240':['p8_ee_ZZ_ecm240'],
+            'p8_ee_ZZ_ecm240':['p8_ee_WW_ecm240'],
+            'wzp6_ee_nunuH_Hbb_ecm240':['wzp6_ee_nunuH_Hbb_ecm240'],
+            'wzp6_ee_nunuH_HWW_ecm240':['wzp6_ee_nunuH_HWW_ecm240']
+                }
+                }
+
+
+legend = {}
+legend['exoticHiggs_scalar_ms20GeV_sine-5_NU'] = 'm_{S} = 20 GeV, sin #theta = 1e-5'
+legend['exoticHiggs_scalar_ms20GeV_sine-6_NU'] = 'm_{S} = 20 GeV, sin #theta = 1e-6'
+legend['exoticHiggs_scalar_ms20GeV_sine-7_NU'] = 'm_{S} = 20 GeV, sin #theta = 1e-7'
+legend['exoticHiggs_scalar_ms60GeV_sine-5_NU'] = 'm_{S} = 60 GeV, sin #theta = 1e-5'
+legend['exoticHiggs_scalar_ms60GeV_sine-6_NU'] = 'm_{S} = 60 GeV, sin #theta = 1e-6'
+legend['exoticHiggs_scalar_ms60GeV_sine-7_NU'] = 'm_{S} = 60 GeV, sin #theta = 1e-7'
+
+legend['p8_ee_WW_ecm240'] = 'e^{-}e^{+} $\rightarrow$ WW'
+legend['p8_ee_ZZ_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZZ'
+legend['wzp6_ee_nunuH_Hbb_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ nu nu, H $\rightarrow$ bb'
+legend['wzp6_ee_nunuH_HWW_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ nu nu, H $\rightarrow$ WW'

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_stage1_H.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_stage1_H.py
@@ -8,37 +8,39 @@ testfile="/afs/cern.ch/work/u/uvandevo/exoticHiggs_scalar_ms20GeV_sine-5.root"
 processList = {
 
         #privately-produced signals
-        'exoticHiggs_scalar_ms20GeV_sine-5':{},
-        'exoticHiggs_scalar_ms20GeV_sine-6':{},
-        'exoticHiggs_scalar_ms20GeV_sine-7':{},
-        'exoticHiggs_scalar_ms60GeV_sine-5':{},
-        'exoticHiggs_scalar_ms60GeV_sine-6':{},
-        'exoticHiggs_scalar_ms60GeV_sine-7':{},
-        #'exoticHiggs_scalar_ms20GeV_sine-5_CLD':{},
-        #'exoticHiggs_scalar_ms20GeV_sine-6_CLD':{},
-        #'exoticHiggs_scalar_ms20GeV_sine-7_CLD':{},
-        #'exoticHiggs_scalar_ms60GeV_sine-5_CLD':{},
-        #'exoticHiggs_scalar_ms60GeV_sine-6_CLD':{},
-        #'exoticHiggs_scalar_ms60GeV_sine-7_CLD':{},
+        'exoticHiggs_scalar_ms20GeV_sine-5_H':{},
+        'exoticHiggs_scalar_ms20GeV_sine-6_H':{},
+        'exoticHiggs_scalar_ms20GeV_sine-7_H':{},
+        'exoticHiggs_scalar_ms60GeV_sine-5_H':{},
+        'exoticHiggs_scalar_ms60GeV_sine-6_H':{},
+        'exoticHiggs_scalar_ms60GeV_sine-7_H':{}
+        
+        # #centrally produced backgrounds
+        #'p8_ee_ZZ_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'p8_ee_WW_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_ccH_HWW_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_qqH_HWW_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_bbH_HWW_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_ssH_HWW_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_ssH_Hbb_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_qqH_Hbb_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_bbH_Hbb_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_ccH_Hbb_ecm240':{'fraction':0.005, 'chunks':5}   
 }
 
 #Production tag. This points to the yaml files for getting sample statistics
 #Mandatory when running over EDM4Hep centrally produced events
 #Comment out when running over privately produced events
-#prodTag     = "FCCee/spring2021/IDEA/"
+#prodTag     = "FCCee/winter2023/IDEA/"
 
 #Input directory
 #Comment out when running over centrally produced events
 #Mandatory when running over privately produced events
-#inputDir = "/afs/cern.ch/work/u/uvandevo"
-inputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/output_MadgraphPythiaDelphes"
-#inputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD"
+inputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD"
 
 #Optional: output directory, default is local dir
-#outputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/MC_output_stage1/"
-#outputDirEos = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/MC_output_stage1/"
-outputDir = "MC_output_stage1/"
-#outputDir = "MC_output_stage1_CLD/"
+outputDir = "MC_output_stage1_H/"
+
 #Optional: ncpus, default is 4
 nCPUS       = 4
 
@@ -64,15 +66,16 @@ class RDFanalysis():
             .Alias("Particle1", "Particle#1.index")
             # MC-particles/truth particles
 
-            # select the generated electrons and positrons
-            .Define('GenElectrons_PID', 'MCParticle::sel_pdgID(11, true)(Particle)')
-            # get the number of generated electrons and positrons
-            .Define('n_GenElectrons', 'MCParticle::get_n(GenElectrons_PID)')
+            # select gen quarks from Z decay (besides b, which is already later selected)
+            .Define('GenU_PID', 'MCParticle::sel_pdgID(2, true)(Particle)')
+            .Define('GenD_PID', 'MCParticle::sel_pdgID(1, true)(Particle)')
+            .Define('GenC_PID', 'MCParticle::sel_pdgID(4, true)(Particle)')
+            .Define('GenS_PID', 'MCParticle::sel_pdgID(3, true)(Particle)')
 
-            # select the generated muons
-            .Define('GenMuons_PID', 'MCParticle::sel_pdgID(13, true)(Particle)')
-            # get the number of generated muons
-            .Define('n_GenMuons', 'MCParticle::get_n(GenMuons_PID)')
+            .Define('n_GenU', 'MCParticle::get_n(GenU_PID)')
+            .Define('n_GenD', 'MCParticle::get_n(GenD_PID)')
+            .Define('n_GenC', 'MCParticle::get_n(GenC_PID)')
+            .Define('n_GenS', 'MCParticle::get_n(GenS_PID)')
 
             # select generated Z boson
             .Define('GenZ_PID',  'MCParticle::sel_pdgID(23, false)(Particle)')
@@ -171,8 +174,10 @@ class RDFanalysis():
     #Mandatory: output function, please make sure you return the branchlist as a python list
     def output():
         branchList = [
-            'n_GenElectrons',
-            'n_GenMuons',
+            'n_GenU',
+            'n_GenD',
+            'n_GenC',
+            'n_GenS',
             'n_GenZ',
             'n_GenHiggs',
             'n_Genb',

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_stage1_NU.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/MC_analysis_stage1_NU.py
@@ -8,37 +8,33 @@ testfile="/afs/cern.ch/work/u/uvandevo/exoticHiggs_scalar_ms20GeV_sine-5.root"
 processList = {
 
         #privately-produced signals
-        'exoticHiggs_scalar_ms20GeV_sine-5':{},
-        'exoticHiggs_scalar_ms20GeV_sine-6':{},
-        'exoticHiggs_scalar_ms20GeV_sine-7':{},
-        'exoticHiggs_scalar_ms60GeV_sine-5':{},
-        'exoticHiggs_scalar_ms60GeV_sine-6':{},
-        'exoticHiggs_scalar_ms60GeV_sine-7':{},
-        #'exoticHiggs_scalar_ms20GeV_sine-5_CLD':{},
-        #'exoticHiggs_scalar_ms20GeV_sine-6_CLD':{},
-        #'exoticHiggs_scalar_ms20GeV_sine-7_CLD':{},
-        #'exoticHiggs_scalar_ms60GeV_sine-5_CLD':{},
-        #'exoticHiggs_scalar_ms60GeV_sine-6_CLD':{},
-        #'exoticHiggs_scalar_ms60GeV_sine-7_CLD':{},
+        'exoticHiggs_scalar_ms20GeV_sine-5_NU':{},
+        'exoticHiggs_scalar_ms20GeV_sine-6_NU':{},
+        'exoticHiggs_scalar_ms20GeV_sine-7_NU':{},
+        'exoticHiggs_scalar_ms60GeV_sine-5_NU':{},
+        'exoticHiggs_scalar_ms60GeV_sine-6_NU':{},
+        'exoticHiggs_scalar_ms60GeV_sine-7_NU':{},
+
+        # #centrally produced backgrounds
+        #'p8_ee_ZZ_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'p8_ee_WW_ecm240':{'fraction':0.005, 'chunks':5},     
+        #'wzp6_ee_nunuH_Hbb_ecm240':{'fraction':0.005, 'chunks':5},
+        #'wzp6_ee_nunuH_HWW_ecm240':{'fraction':0.005, 'chunks':5}
 }
 
 #Production tag. This points to the yaml files for getting sample statistics
 #Mandatory when running over EDM4Hep centrally produced events
 #Comment out when running over privately produced events
-#prodTag     = "FCCee/spring2021/IDEA/"
+#prodTag     = "FCCee/winter2023/IDEA/"
 
 #Input directory
 #Comment out when running over centrally produced events
 #Mandatory when running over privately produced events
-#inputDir = "/afs/cern.ch/work/u/uvandevo"
-inputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/output_MadgraphPythiaDelphes"
-#inputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD"
+inputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD"
 
 #Optional: output directory, default is local dir
-#outputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/MC_output_stage1/"
-#outputDirEos = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/MC_output_stage1/"
-outputDir = "MC_output_stage1/"
-#outputDir = "MC_output_stage1_CLD/"
+outputDir = "MC_output_stage1_NU/"
+
 #Optional: ncpus, default is 4
 nCPUS       = 4
 
@@ -64,15 +60,14 @@ class RDFanalysis():
             .Alias("Particle1", "Particle#1.index")
             # MC-particles/truth particles
 
-            # select the generated electrons and positrons
-            .Define('GenElectrons_PID', 'MCParticle::sel_pdgID(11, true)(Particle)')
-            # get the number of generated electrons and positrons
-            .Define('n_GenElectrons', 'MCParticle::get_n(GenElectrons_PID)')
+            # select the generated neutrinos 
+            .Define('GenElecNeutrinos_PID', 'MCParticle::sel_pdgID(12,true)(Particle)')
+            .Define('GenMuNeutrinos_PID', 'MCParticle::sel_pdgID(14,true)(Particle)')
+            .Define('GenTauNeutrinos_PID', 'MCParticle::sel_pdgID(16,true)(Particle)')
 
-            # select the generated muons
-            .Define('GenMuons_PID', 'MCParticle::sel_pdgID(13, true)(Particle)')
-            # get the number of generated muons
-            .Define('n_GenMuons', 'MCParticle::get_n(GenMuons_PID)')
+            .Define('n_GenElecNeutrinos', 'MCParticle::get_n(GenElecNeutrinos_PID)')
+            .Define('n_GenMuNeutrinos', 'MCParticle::get_n(GenMuNeutrinos_PID)')
+            .Define('n_GenTauNeutrinos', 'MCParticle::get_n(GenTauNeutrinos_PID)')
 
             # select generated Z boson
             .Define('GenZ_PID',  'MCParticle::sel_pdgID(23, false)(Particle)')
@@ -171,8 +166,9 @@ class RDFanalysis():
     #Mandatory: output function, please make sure you return the branchlist as a python list
     def output():
         branchList = [
-            'n_GenElectrons',
-            'n_GenMuons',
+            'n_GenElecNeutrinos',
+            'n_GenMuNeutrinos',
+            'n_GenTauNeutrinos',
             'n_GenZ',
             'n_GenHiggs',
             'n_Genb',

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_final.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_final.py
@@ -1,15 +1,16 @@
 #Input directory where the files produced at the stage1 level are
 inputDir  = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/Reco_output_stage1/"
+#inputDir  = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD/Reco_output_stage1_CLD/"
 
 #Output directory where the files produced at the final-selection level are
 outputDir  = "Reco_output_finalSel/"
-
+#outputDir  = "Reco_output_finalSel_CLD/"
 
 # # #Integrated luminosity for scaling number of events (required only if setting doScale to true)
-# intLumi = 5e6 #pb^-1
+intLumi = 5e6 #pb^-1
 
 # # #Scale event yields by intLumi and cross section (optional)
-# doScale = True
+doScale = True
 
 # # #Save event yields in a table (optional)
 # saveTabular = True
@@ -24,11 +25,24 @@ processList = {
         'exoticHiggs_scalar_ms60GeV_sine-5':{},
         'exoticHiggs_scalar_ms60GeV_sine-6':{},
         'exoticHiggs_scalar_ms60GeV_sine-7':{},
+        #'exoticHiggs_scalar_ms20GeV_sine-5_CLD':{}, # CLD privately-produced signals 
+        #'exoticHiggs_scalar_ms20GeV_sine-6_CLD':{},
+        #'exoticHiggs_scalar_ms20GeV_sine-7_CLD':{},
+        #'exoticHiggs_scalar_ms60GeV_sine-5_CLD':{},
+        #'exoticHiggs_scalar_ms60GeV_sine-6_CLD':{},
+        #'exoticHiggs_scalar_ms60GeV_sine-7_CLD':{},
 
-        #centrally produced backgrounds
-        'p8_ee_ZZ_ecm240':{},
-        'p8_ee_WW_ecm240':{},
-        'p8_ee_ZH_ecm240':{},
+        # #centrally produced backgrounds
+        # IDEA backgrounds
+        'p8_ee_ZH_ecm240':{'fraction':0.01},
+        'p8_ee_ZZ_ecm240':{'fraction':0.01},   
+        'p8_ee_WW_ecm240':{'fraction':0.01},     
+        
+        # CLD (IDEA_FullSilicon) backgrounds
+        #'p8_ee_ZZ_ecm240':{'fraction':0.01, 'chunks':5},   
+        #'p8_ee_WW_ecm240':{'fraction':0.01, 'chunks':5},     
+        #'wzp6_ee_eeH_HZa_ecm240':{'fraction':0.01, 'chunks':5},   
+        #'wzp6_ee_mumuH_HZa_ecm240':{'fraction':0.01, 'chunks':5},   
 }
 
 ###Dictionary for prettier names of processes (optional)
@@ -41,14 +55,28 @@ processLabels = {
     'exoticHiggs_scalar_ms60GeV_sine-6': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-6}$",
     'exoticHiggs_scalar_ms60GeV_sine-7': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-7}$",
 
+    #'exoticHiggs_scalar_ms20GeV_sine-5_CLD': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-5}$",
+    #'exoticHiggs_scalar_ms20GeV_sine-6_CLD': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-6}$",
+    #'exoticHiggs_scalar_ms20GeV_sine-7_CLD': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-7}$",
+    #'exoticHiggs_scalar_ms60GeV_sine-5_CLD': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-5}$",
+    #'exoticHiggs_scalar_ms60GeV_sine-6_CLD': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-6}$",
+    #'exoticHiggs_scalar_ms60GeV_sine-7_CLD': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-7}$",
+
     #backgrounds
     'p8_ee_WW_ecm240': "e^{-}e^{+} $\rightarrow$ WW",
     'p8_ee_ZZ_ecm240': "e^{-}e^{+} $\rightarrow$ ZZ",
     'p8_ee_ZH_ecm240': "e^{-}e^{+} $\rightarrow$ ZH",
+    
+    # CLD (IDEA_FullSilicon) backgrounds
+    #'p8_ee_WW_ecm240': "e^{-}e^{+} $\rightarrow$ WW",
+    #'p8_ee_ZZ_ecm240': "e^{-}e^{+} $\rightarrow$ ZZ",
+    #'wzp6_ee_eeH_HZa_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, (Z -> e^{-}e^{+})",
+    #'wzp6_ee_mumuH_HZa_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, (Z -> mu^{-}mu^{+})",
 }
 
 #Link to the dictonary that contains all the cross section information etc...
 procDict = "FCCee_procDict_spring2021_IDEA.json"
+#prodDict     = "FCCee/winter2023/IDEA_FullSilicon/"
 
 #Add MySample_p8_ee_ZH_ecm240 as it is not an offical process
 procDictAdd={
@@ -58,6 +86,13 @@ procDictAdd={
     'exoticHiggs_scalar_ms60GeV_sine-5': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 2.618e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
     'exoticHiggs_scalar_ms60GeV_sine-6': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 2.618e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
     'exoticHiggs_scalar_ms60GeV_sine-7': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 2.618e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+
+    #'exoticHiggs_scalar_ms20GeV_sine-5_CLD': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 7.667e-6, "kfactor": 1.0, "matchingEfficiency": 1.0}, # NOTE cross sections use updated kappa value of 7e-4, which was used for sample generation 
+    #'exoticHiggs_scalar_ms20GeV_sine-6_CLD': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 7.667e-6, "kfactor": 1.0, "matchingEfficiency": 1.0}, # unsure if should be updated for IDEA samples too 
+    #'exoticHiggs_scalar_ms20GeV_sine-7_CLD': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 7.667e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    #'exoticHiggs_scalar_ms60GeV_sine-5_CLD': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 2.26666e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    #'exoticHiggs_scalar_ms60GeV_sine-6_CLD': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 2.26666e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    #'exoticHiggs_scalar_ms60GeV_sine-7_CLD': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 2.26666e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
 }
 
 #Number of CPUs to use

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_final_H.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_final_H.py
@@ -1,0 +1,156 @@
+### NOTE: Script still WIP, with these cuts have very poor background rejection
+### Likely want to add more jet variables & perform additional or completely different cuts
+
+#Input directory where the files produced at the stage1 level are
+#inputDir  = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/Reco_output_stage1/"
+#inputDir  = "/eos/experiment/fcc/ee/analyses_storage/BSM/LLPs/ExoticHiggsDecays/Reco_output_stage1/"
+#inputDir = "Reco_output_stage1/exoticHiggs_scalar_ms20GeV_sine-5/"
+#inputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/Reco_output_stage1"
+#inputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD/Reco_output_stage1_H"
+inputDir = "/eos/user/m/mlarson/Reco_output_stage1_H"
+#Output directory where the files produced at the final-selection level are
+outputDir = "Reco_output_final_H/"
+
+
+# # #Integrated luminosity for scaling number of events (required only if setting doScale to true)
+intLumi = 5.0e6 #pb^-1
+
+# # #Scale event yields by intLumi and cross section (optional)
+doScale = True
+
+# # #Save event yields in a table (optional)
+# saveTabular = True
+
+#Mandatory: List of processes
+processList = {
+
+        #privately-produced signals
+        'exoticHiggs_scalar_ms20GeV_sine-5_H':{},
+        'exoticHiggs_scalar_ms20GeV_sine-6_H':{},
+        'exoticHiggs_scalar_ms20GeV_sine-7_H':{},
+        'exoticHiggs_scalar_ms60GeV_sine-5_H':{},
+        'exoticHiggs_scalar_ms60GeV_sine-6_H':{},
+        'exoticHiggs_scalar_ms60GeV_sine-7_H':{},
+
+        # #centrally produced backgrounds
+        'p8_ee_ZZ_ecm240':{},   
+        'p8_ee_WW_ecm240':{},   
+        'wzp6_ee_ccH_HWW_ecm240':{},   
+        'wzp6_ee_qqH_HWW_ecm240':{},   
+        'wzp6_ee_bbH_HWW_ecm240':{},   
+        'wzp6_ee_ssH_HWW_ecm240':{},   
+        'wzp6_ee_ssH_Hbb_ecm240':{},   
+        'wzp6_ee_qqH_Hbb_ecm240':{},   
+        'wzp6_ee_bbH_Hbb_ecm240':{},   
+        'wzp6_ee_ccH_Hbb_ecm240':{}   
+
+}
+
+###Dictionary for prettier names of processes (optional)
+processLabels = {
+    #signals
+    'exoticHiggs_scalar_ms20GeV_sine-5_H': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-5}$",
+    'exoticHiggs_scalar_ms20GeV_sine-6_H': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-6}$",
+    'exoticHiggs_scalar_ms20GeV_sine-7_H': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-7}$",
+    'exoticHiggs_scalar_ms60GeV_sine-5_H': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-5}$",
+    'exoticHiggs_scalar_ms60GeV_sine-6_H': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-6}$",
+    'exoticHiggs_scalar_ms60GeV_sine-7_H': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-7}$",
+
+    # #backgrounds
+    'p8_ee_WW_ecm240': "e^{-}e^{+} $\rightarrow$ WW",
+    'p8_ee_ZZ_ecm240': "e^{-}e^{+} $\rightarrow$ ZZ",
+    'p8_ee_ZH_ecm240': "e^{-}e^{+} $\rightarrow$ ZH",
+    'p8_ee_ZZ_ecm240': "e^{-}e^{+} $\rightarrow$ WW",
+    'p8_ee_WW_ecm240': "e^{-}e^{+} $\rightarrow$ ZZ",
+    'wzp6_ee_ccH_HWW_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ cc, H $\rightarrow$ WW",
+    'wzp6_ee_qqH_HWW_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ 1/2(uu + dd), H $\rightarrow$ WW",
+    'wzp6_ee_bbH_HWW_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ bb, H $\rightarrow$ WW",
+    'wzp6_ee_ssH_HWW_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ ss, H $\rightarrow$ WW",
+    'wzp6_ee_ssH_Hbb_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ ss, H $\rightarrow$ bb",
+    'wzp6_ee_qqH_Hbb_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ 1/2(uu + dd), H $\rightarrow$ bb",
+    'wzp6_ee_bbH_Hbb_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ bb, H $\rightarrow$ bb",
+    'wzp6_ee_ccH_Hbb_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ cc, H $\rightarrow$ bb"
+}
+
+#Link to the dictonary that contains all the cross section information etc...
+procDict = "FCCee_procDict_winter2023_IDEA.json"
+
+#Add MySample_p8_ee_ZH_ecm240 as it is not an offical process
+#OBS NUMBEROFEVENTS AND SUMOFWEIGHTS HAS BEEN MODIFIED FOR DEBUGGING, REMEMBER TO CHANGE BACK
+procDictAdd={
+    'exoticHiggs_scalar_ms20GeV_sine-5_H': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 1.5943e-4, "kfactor": 1.0, "matchingEfficiency": 1.0}, # NOTE cross sections use updated kappa value of 7e-4, which was used for sample generation 
+    'exoticHiggs_scalar_ms20GeV_sine-6_H': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 1.5943e-4, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms20GeV_sine-7_H': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 1.5943e-4, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms60GeV_sine-5_H': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 4.7134e-5, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms60GeV_sine-6_H': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 4.7134e-5, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms60GeV_sine-7_H': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 4.7134e-5, "kfactor": 1.0, "matchingEfficiency": 1.0},
+}
+
+#Number of CPUs to use
+nCPUS = 2
+
+#produces ROOT TTrees, default is False
+doTree = False
+
+###Dictionnay of the list of cuts. The key is the name of the selection that will be added to the output file
+cutList = {
+    # For plotting
+    #"selNone": "n_tracks > -1",
+
+    # For event selection
+    ### preSel "done" at reco stage by clustering 2 jets 
+    "selJetEnergy": "((jets_kt_e_sum > 50) && (jets_kt_e_sum < 140))",
+    "selJetEnergy+nDVs_seltracks": "((jets_kt_e_sum > 50) && (jets_kt_e_sum < 140)) && filter_n_DVs_seltracks > 1",
+    "selJetEnergy+nDVs_merge": "((jets_kt_e_sum > 50) && (jets_kt_e_sum < 140)) && filter_n_DVs_merge > 1"
+}
+
+###Dictionary for prettier names of cuts (optional)
+cutLabels = {
+    # For plotting
+    #"selNone": "Before selection",
+
+    # For event selection
+    ### preSel "done" at reco stage by clustering 2 jets 
+    "selJetEnergy": "50 < $E_jet1 + E_jet2$ < 140 GeV",
+    "selJetEnergy+nDVs_seltracks": "n DVs $\geq$ 2",
+    "selJetEnergy+nDVs_merge": "n DVs $\geq$ 2 (merged)",
+}
+
+###Dictionary for the ouput variable/hitograms. The key is the name of the variable in the output files. "name" is the name of the variable in the input file, "title" is the x-axis label of the histogram, "bin" the number of bins of the histogram, "xmin" the minimum x-axis value and "xmax" the maximum x-axis value.
+
+histoList = {
+    "n_tracks":                             {"name":"n_tracks",                 "title":"Number of reconstructed tracks",                          "bin":100, "xmin":-0.5,"xmax":99.5},
+    "n_RecoedPrimaryTracks":                {"name":"n_RecoedPrimaryTracks",    "title": "Number of reconstructed primary tracks",                 "bin":10, "xmin":-0.5,"xmax":9.5},
+    'n_seltracks_DVs':                      {"name":"n_seltracks_DVs",           "title":"Number of DVs",                                           "bin":12, "xmin":-0.5, "xmax":11.5},
+    'n_trks_seltracks_DVs':                 {"name":'n_trks_seltracks_DVs',       "title":"Number of tracks from the DVs",                          "bin":30, "xmin":1.5, "xmax":29.5},
+    'invMass_seltracks_DVs':                {"name":'invMass_seltracks_DVs',      "title":"Invariant mass at the DVs [GeV]",                           "bin":40, "xmin":-0.5, "xmax":39.5},
+    "DV_evt_seltracks_chi2":                {"name":"DV_evt_seltracks_chi2",    "title":"The #chi^{2} distribution of the DVs",                    "bin":100, "xmin":-0.5, "xmax":11.5},
+    "Reco_seltracks_DVs_Lxy":               {"name":"Reco_seltracks_DVs_Lxy",     "title":"Transverse distance between PV and DVs [mm]",               "bin":100, "xmin":0, "xmax":300},
+    "Reco_seltracks_DVs_Lxyz":              {"name":"Reco_seltracks_DVs_Lxyz",    "title":"Distance between PV and DVs [mm]",                          "bin":100, "xmin":0, "xmax":2000},
+    "DV_evt_seltracks_normchi2":            {"name":"DV_evt_seltracks_normchi2",    "title":"The normalised #chi^{2} distribution of the DVs",      "bin":40, "xmin":0, "xmax":10},
+    "merged_DVs_n":                         {"name":"merged_DVs_n",              "title":"Number of DVs",                                           "bin":10, "xmin":-0.5, "xmax":9.5},
+    'n_trks_merged_DVs':                    {"name":'n_trks_merged_DVs',       "title":"Number of tracks from the DVs from sel tracks + merge",   "bin":30, "xmin":1.5, "xmax":29.5},
+    'invMass_merged_DVs':                   {"name":'invMass_merged_DVs',      "title":"Invariant mass at the DVs [GeV]",                           "bin":40, "xmin":-0.5, "xmax":39.5},
+    "merged_DVs_chi2":                      {"name":"merged_DVs_chi2",          "title":"The #chi^{2} distribution of the merged DVs",              "bin":100, "xmin":-0.5, "xmax":11.5},
+    "merged_DVs_normchi2":                  {"name":"merged_DVs_normchi2",       "title":"The normalised #chi^{2} distribution of the merged DVs",    "bin":40, "xmin":0, "xmax":10},
+    "Reco_DVs_merged_Lxy":                  {"name":"Reco_DVs_merged_Lxy",     "title":"Transverse distance between PV and DVs [mm]",               "bin":100, "xmin":0, "xmax":300},
+    "Reco_DVs_merged_Lxyz":                 {"name":"Reco_DVs_merged_Lxyz",    "title":"Distance between PV and DVs [mm]",                          "bin":100, "xmin":0, "xmax":2000},
+
+    #"jets_kt_e":                            {"name":"jets_kt_e",    "title":"Reco. Jet Energy [GeV]",                                               "bin":100, "xmin":0, "xmax":100},
+    #"jets_kt_px":                           {"name":"jets_kt_px",    "title":"Reco. Jet Momenutm (along x-axis) [GeV]",                             "bin":100, "xmin":-50, "xmax":50},
+    #"jets_kt_py":                           {"name":"jets_kt_py",    "title":"Reco. Jet Momenutm (along y-axis) [GeV]",                             "bin":100, "xmin":-50, "xmax":50},
+    #"jets_kt_pz":                           {"name":"jets_kt_pz",    "title":"Reco. Jet Momenutm (along z-axis) [GeV]",                             "bin":100, "xmin":-50, "xmax":50},
+    #"jets_kt_m":                            {"name":"jets_kt_m",    "title":"Reco. Jet Mass [GeV]",                                                 "bin":100, "xmin":0, "xmax":100},
+    #"jetconstituents_kt":                   {"name":"jetconstituents_kt",    "title":"Jet Constituent Objects (showing # Reco. jets)",              "bin":20, "xmin":-10, "xmax":10},
+
+    "jets_kt_e_sum":                        {"name":"jets_kt_e_sum",    "title":"Total Reco. Jet Energy [GeV]",                                     "bin":100, "xmin":0, "xmax":200},
+    "jets_kt_px_sum":                       {"name":"jets_kt_px_sum",    "title":"Total Reco. Jet Momenutm (along x-axis) [GeV]",                   "bin":100, "xmin":-100, "xmax":100},
+    "jets_kt_py_sum":                       {"name":"jets_kt_py_sum",    "title":"Total Reco. Jet Momenutm (along y-axis) [GeV]",                   "bin":100, "xmin":-100, "xmax":100},
+    "jets_kt_pz_sum":                       {"name":"jets_kt_pz_sum",    "title":"Total Reco. Jet Momenutm (along z-axis) [GeV]",                   "bin":100, "xmin":-100, "xmax":100},
+
+    "jets_kt_e_avg":                        {"name":"jets_kt_e_avg",    "title":"Avg. Reco. Jet Energy [GeV]",                                      "bin":100, "xmin":0, "xmax":100},
+    "jets_kt_px_avg":                       {"name":"jets_kt_px_avg",    "title":"Avg. Reco. Jet Momenutm (along x-axis) [GeV]",                    "bin":100, "xmin":-50, "xmax":50},
+    "jets_kt_py_avg":                       {"name":"jets_kt_py_avg",    "title":"Avg. Reco. Jet Momenutm (along y-axis) [GeV]",                    "bin":100, "xmin":-50, "xmax":50},
+    "jets_kt_pz_avg":                       {"name":"jets_kt_pz_avg",    "title":"Avg. Reco. Jet Momenutm (along z-axis) [GeV]",                    "bin":100, "xmin":-50, "xmax":50},
+    
+}

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_final_NU.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_final_NU.py
@@ -1,0 +1,127 @@
+#Input directory where the files produced at the stage1 level are
+inputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD/Reco_output_stage1_NU"
+#inputDir = "/eos/user/m/mlarson/Reco_output_stage1_NU"
+
+#Output directory where the files produced at the final-selection level are
+#outputDir  = "Reco_output_finalSel_IDEA/"
+outputDir = "Reco_output_final_NU/"
+
+# # #Integrated luminosity for scaling number of events (required only if setting doScale to true)
+intLumi = 5.0e6 #pb^-1
+
+# # #Scale event yields by intLumi and cross section (optional)
+doScale = True
+
+# # #Save event yields in a table (optional)
+# saveTabular = True
+
+#Mandatory: List of processes
+processList = {
+
+        #privately-produced signals
+        'exoticHiggs_scalar_ms20GeV_sine-5_NU':{},
+        'exoticHiggs_scalar_ms20GeV_sine-6_NU':{},
+        'exoticHiggs_scalar_ms20GeV_sine-7_NU':{},
+        'exoticHiggs_scalar_ms60GeV_sine-5_NU':{},
+        'exoticHiggs_scalar_ms60GeV_sine-6_NU':{},
+        'exoticHiggs_scalar_ms60GeV_sine-7_NU':{},
+
+        #centrally produced backgrounds
+        'p8_ee_ZZ_ecm240':{},
+        'p8_ee_WW_ecm240':{},
+        'wzp6_ee_nunuH_Hbb_ecm240':{},
+        'wzp6_ee_nunuH_HWW_ecm240':{}
+}
+
+###Dictionary for prettier names of processes (optional)
+processLabels = {
+    #signals
+    'exoticHiggs_scalar_ms20GeV_sine-5_NU': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-5}$",
+    'exoticHiggs_scalar_ms20GeV_sine-6_NU': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-6}$",
+    'exoticHiggs_scalar_ms20GeV_sine-7_NU': "$m_S$ = 20 GeV, sin $\theta = 1 * 10^{-7}$",
+    'exoticHiggs_scalar_ms60GeV_sine-5_NU': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-5}$",
+    'exoticHiggs_scalar_ms60GeV_sine-6_NU': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-6}$",
+    'exoticHiggs_scalar_ms60GeV_sine-7_NU': "$m_S$ = 60 GeV, sin $\theta = 1 * 10^{-7}$",
+
+    # #backgrounds
+    'p8_ee_WW_ecm240': "e^{-}e^{+} $\rightarrow$ WW",
+    'p8_ee_ZZ_ecm240': "e^{-}e^{+} $\rightarrow$ ZZ",
+    'wzp6_ee_nunuH_Hbb_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ nu nu, H $\rightarrow$ bb",
+    'wzp6_ee_nunuH_HWW_ecm240': "e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ nu nu, H $\rightarrow$ WW",
+}
+
+#Link to the dictonary that contains all the cross section information etc...
+procDict = "FCCee_procDict_winter2023_IDEA.json"
+
+#Add MySample_p8_ee_ZH_ecm240 as it is not an offical process
+#OBS NUMBEROFEVENTS AND SUMOFWEIGHTS HAS BEEN MODIFIED FOR DEBUGGING, REMEMBER TO CHANGE BACK
+procDictAdd={
+    'exoticHiggs_scalar_ms20GeV_sine-5_NU': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 2.2797e-5, "kfactor": 1.0, "matchingEfficiency": 1.0}, # NOTE cross sections use updated kappa value of 7e-4, which was used for sample generation 
+    'exoticHiggs_scalar_ms20GeV_sine-6_NU': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 2.2797e-5, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms20GeV_sine-7_NU': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 2.2797e-5, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms60GeV_sine-5_NU': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 6.7396e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms60GeV_sine-6_NU': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 6.7396e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    'exoticHiggs_scalar_ms60GeV_sine-7_NU': {"numberOfEvents": 10000, "sumOfWeights": 10000, "crossSection": 6.7396e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
+}
+
+#Number of CPUs to use
+nCPUS = 2
+
+#produces ROOT TTrees, default is False
+doTree = False
+
+###Dictionnay of the list of cuts. The key is the name of the selection that will be added to the output file
+cutList = {
+    # For plotting
+    #"selNone": "n_tracks > -1",
+
+    # For event selection
+    "preSel": "((RecoMissingEnergy_e_sum > 30) && (RecoMissingEnergy_e_sum < 70))",
+    "preSel+nDVs_seltracks": "((RecoMissingEnergy_e_sum > 30) && (RecoMissingEnergy_e_sum < 70)) && filter_n_DVs_seltracks > 1",
+    "preSel+nDVs_merge": "((RecoMissingEnergy_e_sum > 30) && (RecoMissingEnergy_e_sum < 70)) && filter_n_DVs_merge > 1",
+}
+
+###Dictionary for prettier names of cuts (optional)
+cutLabels = {
+    # For plotting
+    #"selNone": "Before selection",
+
+    # For event selection
+    "preSel": "> 30 GeV Missing Energy",
+    "preSel+nDVs_seltracks": "n DVs $\geq$ 2",
+    "preSel+nDVs_merge": "n DVs $\geq$ 2 (merged)",
+}
+
+###Dictionary for the ouput variable/hitograms. The key is the name of the variable in the output files. "name" is the name of the variable in the input file, "title" is the x-axis label of the histogram, "bin" the number of bins of the histogram, "xmin" the minimum x-axis value and "xmax" the maximum x-axis value.
+
+histoList = {
+    "n_tracks":                             {"name":"n_tracks",                 "title":"Number of reconstructed tracks",                          "bin":100, "xmin":-0.5,"xmax":99.5},
+    "n_RecoedPrimaryTracks":                {"name":"n_RecoedPrimaryTracks",    "title": "Number of reconstructed primary tracks",                 "bin":10, "xmin":-0.5,"xmax":9.5},
+    'n_seltracks_DVs':                      {"name":"n_seltracks_DVs",           "title":"Number of DVs",                                           "bin":12, "xmin":-0.5, "xmax":11.5},
+    'n_trks_seltracks_DVs':                 {"name":'n_trks_seltracks_DVs',       "title":"Number of tracks from the DVs",                          "bin":30, "xmin":1.5, "xmax":29.5},
+    'invMass_seltracks_DVs':                {"name":'invMass_seltracks_DVs',      "title":"Invariant mass at the DVs [GeV]",                           "bin":40, "xmin":-0.5, "xmax":39.5},
+    "DV_evt_seltracks_chi2":                {"name":"DV_evt_seltracks_chi2",    "title":"The #chi^{2} distribution of the DVs",                    "bin":100, "xmin":-0.5, "xmax":11.5},
+    "Reco_seltracks_DVs_Lxy":               {"name":"Reco_seltracks_DVs_Lxy",     "title":"Transverse distance between PV and DVs [mm]",               "bin":100, "xmin":0, "xmax":300},
+    "Reco_seltracks_DVs_Lxyz":              {"name":"Reco_seltracks_DVs_Lxyz",    "title":"Distance between PV and DVs [mm]",                          "bin":100, "xmin":0, "xmax":2000},
+    "DV_evt_seltracks_normchi2":            {"name":"DV_evt_seltracks_normchi2",    "title":"The normalised #chi^{2} distribution of the DVs",      "bin":40, "xmin":0, "xmax":10},
+    "merged_DVs_n":                         {"name":"merged_DVs_n",              "title":"Number of DVs",                                           "bin":10, "xmin":-0.5, "xmax":9.5},
+    'n_trks_merged_DVs':                    {"name":'n_trks_merged_DVs',       "title":"Number of tracks from the DVs from sel tracks + merge",   "bin":30, "xmin":1.5, "xmax":29.5},
+    'invMass_merged_DVs':                   {"name":'invMass_merged_DVs',      "title":"Invariant mass at the DVs [GeV]",                           "bin":40, "xmin":-0.5, "xmax":39.5},
+    "merged_DVs_chi2":                      {"name":"merged_DVs_chi2",          "title":"The #chi^{2} distribution of the merged DVs",              "bin":100, "xmin":-0.5, "xmax":11.5},
+    "merged_DVs_normchi2":                  {"name":"merged_DVs_normchi2",       "title":"The normalised #chi^{2} distribution of the merged DVs",    "bin":40, "xmin":0, "xmax":10},
+    "Reco_DVs_merged_Lxy":                  {"name":"Reco_DVs_merged_Lxy",     "title":"Transverse distance between PV and DVs [mm]",               "bin":100, "xmin":0, "xmax":300},
+    "Reco_DVs_merged_Lxyz":                 {"name":"Reco_DVs_merged_Lxyz",    "title":"Distance between PV and DVs [mm]",                          "bin":100, "xmin":0, "xmax":2000},
+    
+    "RecoMissingEnergy_e_sum":              {"name":"RecoMissingEnergy_e_sum",     "title":"Reco. Missing Energy [GeV]",                            "bin":80, "xmin":0, "xmax":80},
+    "RecoMissingEnergy_p_sum":              {"name":"RecoMissingEnergy_p_sum",     "title":"Reco. Missing Momentum [GeV]",                          "bin":80, "xmin":0, "xmax":80},
+    "RecoMissingEnergy_pt_sum":             {"name":"RecoMissingEnergy_pt_sum",    "title":"Reco. Missing Transverse Momentum [GeV]",               "bin":80, "xmin":0, "xmax":80},
+    "RecoMissingEnergy_px_sum":             {"name":"RecoMissingEnergy_px_sum",    "title":"Reco. Missing Momenutm (along x-axis) [GeV]",           "bin":140, "xmin":-70, "xmax":70},
+    "RecoMissingEnergy_py_sum":             {"name":"RecoMissingEnergy_py_sum",    "title":"Reco. Missing Momenutm (along y-axis) [GeV]",           "bin":140, "xmin":-70, "xmax":70},
+    "RecoMissingEnergy_pz_sum":             {"name":"RecoMissingEnergy_pz_sum",    "title":"Reco. Missing Momenutm (along z-axis) [GeV]",           "bin":140, "xmin":-70, "xmax":70},
+    "RecoMissingEnergy_eta_sum":            {"name":"RecoMissingEnergy_eta_sum",   "title":"Reco. Mising Energy eta",                               "bin":100, "xmin":-4, "xmax":4},
+    "RecoMissingEnergy_theta_sum":          {"name":"RecoMissingEnergy_theta_sum", "title":"Reco. Mising Energy theta",                             "bin":64, "xmin":0, "xmax":3.2},
+    "RecoMissingEnergy_phi_sum":            {"name":"RecoMissingEnergy_phi_sum",   "title":"Reco. Mising Energy phi",                               "bin":64, "xmin":-3.2, "xmax":3.2}
+   
+
+    
+}

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_plots.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_plots.py
@@ -12,12 +12,14 @@ delphesVersion = '3.4.2'
 energy         = 240
 collider       = 'FCC-ee'
 inputDir       = 'Reco_output_finalSelPlots/'
+#inputDir       = 'Reco_output_finalSel_CLD/'
 #formats        = ['png','pdf']
 formats        = ['pdf']
 # yaxis          = ['lin','log']
 yaxis          = ['log']
 stacksig       = ['nostack']
 outdir         = 'Reco_plots/'
+#outdir         = 'Reco_plots_CLD/'
 splitLeg       = True
 
 variables = [

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_plots_H.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_plots_H.py
@@ -1,0 +1,129 @@
+import ROOT
+
+### NOTE: plots won't be legible / won't fit including all signals and backgrounds, so some will need to be commented out before running to use plots
+
+# global parameters
+intLumi        = 5.0e+06 #in pb-1
+
+###If scaleSig=0 or scaleBack=0, we don't apply any additional scaling, on top of the normalization to cross section and integrated luminosity, as defined in finalSel.py
+###If scaleSig or scaleBack is not defined, plots will be normalized to 1
+#scaleSig       = 0.
+#scaleBack      = 0.
+ana_tex        = 'e^{+}e^{-} #rightarrow Z h, Z #rightarrow q^{+}q^{-}, h #rightarrow ss #rightarrow b #bar{b} b #bar{b}'
+delphesVersion = '3.4.2'
+energy         = 240
+collider       = 'FCC-ee'
+inputDir       = 'Reco_output_final_H/'
+#formats        = ['png','pdf']
+formats        = ['pdf']
+# yaxis          = ['lin','log']
+yaxis          = ['log']
+stacksig       = ['nostack']
+outdir         = 'Reco_plots_H/'
+splitLeg       = True
+
+variables = [
+
+    #gen variables
+    "n_tracks",
+    "n_RecoedPrimaryTracks",
+    'n_seltracks_DVs',
+    'n_trks_seltracks_DVs',
+    'invMass_seltracks_DVs',
+    "DV_evt_seltracks_chi2",
+    "Reco_seltracks_DVs_Lxy",
+    "Reco_seltracks_DVs_Lxyz",
+    "DV_evt_seltracks_normchi2",
+    "merged_DVs_n",
+    'n_trks_merged_DVs',
+    'invMass_merged_DVs',
+    "merged_DVs_chi2",
+    "merged_DVs_normchi2",
+    "Reco_DVs_merged_Lxy",
+    "Reco_DVs_merged_Lxyz",
+    "jets_kt_e_sum",
+    "jets_kt_px_sum",
+    "jets_kt_py_sum",
+    "jets_kt_pz_sum"
+
+
+             ]
+
+    
+###Dictionary with the analysis name as a key, and the list of selections to be plotted for this analysis. The name of the selections should be the same than in the final selection
+selections = {}
+selections['ExoticHiggs']  = [
+    #"selNone",
+    "selJetEnergy",
+    "selJetEnergy+nDVs_seltracks",
+    "selJetEnergy+nDVs_merge",
+]
+
+extralabel = {}
+#extralabel['selNone'] = "Before selection"
+extralabel['selJetEnergy'] = "50 < $E_jet1 + E_jet2$ < 140 GeV "
+extralabel['selJetEnergy+nDVs_seltracks'] = ">= 2 DVs"
+extralabel['selJetEnergy+nDVs_merge'] = ">= 2 Merged DVs"
+
+colors = {}
+colors['exoticHiggs_scalar_ms20GeV_sine-5_H'] = ROOT.kRed
+colors['exoticHiggs_scalar_ms20GeV_sine-6_H'] = ROOT.kBlue
+colors['exoticHiggs_scalar_ms20GeV_sine-7_H'] = ROOT.kGreen
+colors['exoticHiggs_scalar_ms60GeV_sine-5_H'] = ROOT.kBlack
+colors['exoticHiggs_scalar_ms60GeV_sine-6_H'] = ROOT.kOrange+1
+colors['exoticHiggs_scalar_ms60GeV_sine-7_H'] = ROOT.kViolet-4
+
+colors['p8_ee_ZZ_ecm240'] = ROOT.kAzure
+colors['p8_ee_WW_ecm240'] = ROOT.kCyan
+colors['wzp6_ee_ccH_HWW_ecm240'] = ROOT.kGray
+colors['wzp6_ee_qqH_HWW_ecm240'] = ROOT.kRed-4
+colors['wzp6_ee_bbH_HWW_ecm240'] = ROOT.kBlue-5
+colors['wzp6_ee_ssH_HWW_ecm240'] = ROOT.kCyan+8
+colors['wzp6_ee_ssH_Hbb_ecm240'] = ROOT.kGreen+4
+colors['wzp6_ee_qqH_Hbb_ecm240'] = ROOT.kSpring+8
+colors['wzp6_ee_bbH_Hbb_ecm240'] = ROOT.kYellow-5
+colors['wzp6_ee_ccH_Hbb_ecm240'] = ROOT.kOrange+9
+
+plots = {}
+plots['ExoticHiggs'] = {'signal':{
+                    'exoticHiggs_scalar_ms20GeV_sine-5_H':['exoticHiggs_scalar_ms20GeV_sine-5_H'],
+                    'exoticHiggs_scalar_ms20GeV_sine-6_H':['exoticHiggs_scalar_ms20GeV_sine-6_H'],
+                    'exoticHiggs_scalar_ms20GeV_sine-7_H':['exoticHiggs_scalar_ms20GeV_sine-7_H'],
+                    'exoticHiggs_scalar_ms60GeV_sine-5_H':['exoticHiggs_scalar_ms60GeV_sine-5_H'],
+                    'exoticHiggs_scalar_ms60GeV_sine-6_H':['exoticHiggs_scalar_ms60GeV_sine-6_H'],
+                    'exoticHiggs_scalar_ms60GeV_sine-7_H':['exoticHiggs_scalar_ms60GeV_sine-7_H']
+},
+'backgrounds':{
+                'p8_ee_ZZ_ecm240':['p8_ee_ZZ_ecm240'],
+                'p8_ee_WW_ecm240':['p8_ee_WW_ecm240'],
+                'wzp6_ee_ccH_HWW_ecm240':['wzp6_ee_ccH_HWW_ecm240'],
+                'wzp6_ee_qqH_HWW_ecm240':['wzp6_ee_qqH_HWW_ecm240'],
+                'wzp6_ee_bbH_HWW_ecm240':['wzp6_ee_bbH_HWW_ecm240'],
+                'wzp6_ee_ssH_HWW_ecm240':['wzp6_ee_ssH_HWW_ecm240'],
+                'wzp6_ee_ssH_Hbb_ecm240':['wzp6_ee_ssH_Hbb_ecm240'],
+                'wzp6_ee_qqH_Hbb_ecm240':['wzp6_ee_qqH_Hbb_ecm240'],
+                'wzp6_ee_bbH_Hbb_ecm240':['wzp6_ee_bbH_Hbb_ecm240'],
+                'wzp6_ee_ccH_Hbb_ecm240':['wzp6_ee_ccH_Hbb_ecm240']
+                }
+                }
+
+
+legend = {}
+legend['exoticHiggs_scalar_ms20GeV_sine-5_H'] = 'm_{S} = 20 GeV, sin #theta = 1e-5'
+legend['exoticHiggs_scalar_ms20GeV_sine-6_H'] = 'm_{S} = 20 GeV, sin #theta = 1e-6'
+legend['exoticHiggs_scalar_ms20GeV_sine-7_H'] = 'm_{S} = 20 GeV, sin #theta = 1e-7'
+legend['exoticHiggs_scalar_ms60GeV_sine-5_H'] = 'm_{S} = 60 GeV, sin #theta = 1e-5'
+legend['exoticHiggs_scalar_ms60GeV_sine-6_H'] = 'm_{S} = 60 GeV, sin #theta = 1e-6'
+legend['exoticHiggs_scalar_ms60GeV_sine-7_H'] = 'm_{S} = 60 GeV, sin #theta = 1e-7'
+
+legend['p8_ee_ZZ_ecm240'] = 'e^{+}e^{-} #rightarrow ZZ'
+legend['p8_ee_WW_ecm240'] = 'e^{+}e^{-} #rightarrow WW'
+legend['wzp6_ee_ccH_HWW_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ cc, H $\rightarrow$ WW'
+legend['wzp6_ee_qqH_HWW_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ 1/2(uu + dd), H $\rightarrow$ WW'
+legend['wzp6_ee_bbH_HWW_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ bb, H $\rightarrow$ WW'
+legend['wzp6_ee_ssH_HWW_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ ss, H $\rightarrow$ WW'
+legend['wzp6_ee_ssH_Hbb_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ ss, H $\rightarrow$ bb'
+legend['wzp6_ee_qqH_Hbb_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ 1/2(uu + dd), H $\rightarrow$ bb'
+legend['wzp6_ee_bbH_Hbb_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ bb, H $\rightarrow$ bb'
+legend['wzp6_ee_ccH_Hbb_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ cc, H $\rightarrow$ bb'
+

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_plots_NU.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_plots_NU.py
@@ -1,0 +1,113 @@
+import ROOT
+
+### NOTE: plots won't be legible / won't fit including all signals and backgrounds, so some will need to be commented out before running to use plots
+
+# global parameters
+intLumi        = 5.0e+06 #in pb-1
+
+###If scaleSig=0 or scaleBack=0, we don't apply any additional scaling, on top of the normalization to cross section and integrated luminosity, as defined in finalSel.py
+###If scaleSig or scaleBack is not defined, plots will be normalized to 1
+#scaleSig       = 0.
+#scaleBack      = 0.
+ana_tex        = 'e^{+}e^{-} #rightarrow Z h, Z #rightarrow nu nu, h #rightarrow ss #rightarrow b #bar{b} b #bar{b}'
+delphesVersion = '3.4.2'
+energy         = 240
+collider       = 'FCC-ee'
+inputDir       = 'Reco_output_final_NU/'
+#formats        = ['png','pdf']
+formats        = ['pdf']
+# yaxis          = ['lin','log']
+yaxis          = ['log']
+stacksig       = ['nostack']
+outdir         = 'Reco_plots_NU/'
+splitLeg       = True
+
+variables = [
+
+    #gen variables
+    "n_tracks",
+    "n_RecoedPrimaryTracks",
+    'n_seltracks_DVs',
+    'n_trks_seltracks_DVs',
+    'invMass_seltracks_DVs',
+    "DV_evt_seltracks_chi2",
+    "Reco_seltracks_DVs_Lxy",
+    "Reco_seltracks_DVs_Lxyz",
+    "DV_evt_seltracks_normchi2",
+    "merged_DVs_n",
+    'n_trks_merged_DVs',
+    'invMass_merged_DVs',
+    "merged_DVs_chi2",
+    "merged_DVs_normchi2",
+    "Reco_DVs_merged_Lxy",
+    "Reco_DVs_merged_Lxyz",
+    "RecoMissingEnergy_e_sum",
+    "RecoMissingEnergy_p_sum",
+    "RecoMissingEnergy_pt_sum",
+    "RecoMissingEnergy_px_sum",
+    "RecoMissingEnergy_py_sum",
+    "RecoMissingEnergy_pz_sum",
+    "RecoMissingEnergy_eta_sum",
+    "RecoMissingEnergy_theta_sum",
+    "RecoMissingEnergy_phi_sum"
+             ]
+
+    
+###Dictionary with the analysis name as a key, and the list of selections to be plotted for this analysis. The name of the selections should be the same than in the final selection
+selections = {}
+selections['ExoticHiggs']  = [
+    #"selNone",
+    "preSel",
+    "preSel+nDVs_seltracks",
+    "preSel+nDVs_merge"
+]
+
+extralabel = {}
+#extralabel['selNone'] = "Before selection"
+extralabel['preSel'] = "30 < Missing energy < 70 GeV"
+extralabel['preSel+nDVs_seltracks'] = ">= 2 DVs"
+extralabel['preSel+nDVs_merge'] = ">= 2 Merged DVs"
+
+colors = {}
+colors['exoticHiggs_scalar_ms20GeV_sine-5_NU'] = ROOT.kRed
+colors['exoticHiggs_scalar_ms20GeV_sine-6_NU'] = ROOT.kBlue
+colors['exoticHiggs_scalar_ms20GeV_sine-7_NU'] = ROOT.kGreen
+colors['exoticHiggs_scalar_ms60GeV_sine-5_NU'] = ROOT.kBlack
+colors['exoticHiggs_scalar_ms60GeV_sine-6_NU'] = ROOT.kOrange+1
+colors['exoticHiggs_scalar_ms60GeV_sine-7_NU'] = ROOT.kViolet-4
+
+colors['p8_ee_WW_ecm240'] = ROOT.kAzure
+colors['p8_ee_ZZ_ecm240'] = ROOT.kCyan
+colors['wzp6_ee_nunuH_Hbb_ecm240'] = ROOT.kGray
+colors['wzp6_ee_nunuH_HWW_ecm240'] = ROOT.kRed-4
+
+plots = {}
+plots['ExoticHiggs'] = {'signal':{
+                    'exoticHiggs_scalar_ms20GeV_sine-5_NU':['exoticHiggs_scalar_ms20GeV_sine-5_NU'],
+                    'exoticHiggs_scalar_ms20GeV_sine-6_NU':['exoticHiggs_scalar_ms20GeV_sine-6_NU'],
+                    'exoticHiggs_scalar_ms20GeV_sine-7_NU':['exoticHiggs_scalar_ms20GeV_sine-7_NU'],
+                    'exoticHiggs_scalar_ms60GeV_sine-5_NU':['exoticHiggs_scalar_ms60GeV_sine-5_NU'],
+                    'exoticHiggs_scalar_ms60GeV_sine-6_NU':['exoticHiggs_scalar_ms60GeV_sine-6_NU'],
+                    'exoticHiggs_scalar_ms60GeV_sine-7_NU':['exoticHiggs_scalar_ms60GeV_sine-7_NU']
+},
+'backgrounds':{
+            'p8_ee_WW_ecm240':['p8_ee_ZZ_ecm240'],
+            'p8_ee_ZZ_ecm240':['p8_ee_WW_ecm240'],
+            'wzp6_ee_nunuH_Hbb_ecm240':['wzp6_ee_nunuH_Hbb_ecm240'],
+            'wzp6_ee_nunuH_HWW_ecm240':['wzp6_ee_nunuH_HWW_ecm240']
+                }
+                }
+
+
+legend = {}
+legend['exoticHiggs_scalar_ms20GeV_sine-5_NU'] = 'm_{S} = 20 GeV, sin #theta = 1e-5'
+legend['exoticHiggs_scalar_ms20GeV_sine-6_NU'] = 'm_{S} = 20 GeV, sin #theta = 1e-6'
+legend['exoticHiggs_scalar_ms20GeV_sine-7_NU'] = 'm_{S} = 20 GeV, sin #theta = 1e-7'
+legend['exoticHiggs_scalar_ms60GeV_sine-5_NU'] = 'm_{S} = 60 GeV, sin #theta = 1e-5'
+legend['exoticHiggs_scalar_ms60GeV_sine-6_NU'] = 'm_{S} = 60 GeV, sin #theta = 1e-6'
+legend['exoticHiggs_scalar_ms60GeV_sine-7_NU'] = 'm_{S} = 60 GeV, sin #theta = 1e-7'
+
+legend['p8_ee_WW_ecm240'] = 'e^{-}e^{+} $\rightarrow$ WW'
+legend['p8_ee_ZZ_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZZ'
+legend['wzp6_ee_nunuH_Hbb_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ nu nu, H $\rightarrow$ bb'
+legend['wzp6_ee_nunuH_HWW_ecm240'] = 'e^{-}e^{+} $\rightarrow$ ZH, Z $\rightarrow$ nu nu, H $\rightarrow$ WW'

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_stage1_H.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_stage1_H.py
@@ -1,56 +1,45 @@
 import ROOT
 
-testFile = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/output_MadgraphPythiaDelphes/exoticHiggs_scalar_ms20GeV_sine-6.root"
+testFile = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD/exoticHiggs_scalar_ms20GeV_sine-5_H.root"
 
 #Mandatory: List of processes
 processList = {
 
         #privately-produced signals
-        'exoticHiggs_scalar_ms20GeV_sine-5':{},
-        'exoticHiggs_scalar_ms20GeV_sine-6':{},
-        'exoticHiggs_scalar_ms20GeV_sine-7':{},
-        'exoticHiggs_scalar_ms60GeV_sine-5':{},
-        'exoticHiggs_scalar_ms60GeV_sine-6':{},
-        'exoticHiggs_scalar_ms60GeV_sine-7':{},
-        #'exoticHiggs_scalar_ms20GeV_sine-5_CLD':{}, # CLD privately-produced signals 
-        #'exoticHiggs_scalar_ms20GeV_sine-6_CLD':{},
-        #'exoticHiggs_scalar_ms20GeV_sine-7_CLD':{},
-        #'exoticHiggs_scalar_ms60GeV_sine-5_CLD':{},
-        #'exoticHiggs_scalar_ms60GeV_sine-6_CLD':{},
-        #'exoticHiggs_scalar_ms60GeV_sine-7_CLD':{},
+        'exoticHiggs_scalar_ms20GeV_sine-5_H':{},
+        'exoticHiggs_scalar_ms20GeV_sine-6_H':{},
+        'exoticHiggs_scalar_ms20GeV_sine-7_H':{},
+        'exoticHiggs_scalar_ms60GeV_sine-5_H':{},
+        'exoticHiggs_scalar_ms60GeV_sine-6_H':{},
+        'exoticHiggs_scalar_ms60GeV_sine-7_H':{},
 
         # #centrally produced backgrounds
-        # IDEA backgrounds
-        # 'p8_ee_ZH_ecm240':{'fraction':0.01},
-        # 'p8_ee_ZZ_ecm240':{'fraction':0.01},   
-        # 'p8_ee_WW_ecm240':{'fraction':0.01},     
-        
-        # CLD (IDEA_FullSilicon) backgrounds
-        #'p8_ee_ZH_ecm240':{'fraction':0.01, 'chunks':5},
-        #'p8_ee_ZZ_ecm240':{'fraction':0.01, 'chunks':5},   
-        #'p8_ee_WW_ecm240':{'fraction':0.01, 'chunks':5},     
-        #'wzp6_ee_eeH_HZa_ecm240':{'fraction':0.01, 'chunks':5},   
-        #'wzp6_ee_mumuH_HZa_ecm240':{'fraction':0.01, 'chunks':5},   
+        #'p8_ee_ZZ_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'p8_ee_WW_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_ccH_HWW_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_qqH_HWW_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_bbH_HWW_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_ssH_HWW_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_ssH_Hbb_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_qqH_Hbb_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_bbH_Hbb_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'wzp6_ee_ccH_Hbb_ecm240':{'fraction':0.005, 'chunks':5}   
+
 }
 
 #Production tag. This points to the yaml files for getting sample statistics
 #Mandatory when running over EDM4Hep centrally produced events
 #Comment out when running over privately produced events
-#prodTag     = "FCCee/spring2021/IDEA/"
-#prodTag     = "FCCee/winter2023/IDEA_FullSilicon/"
-
+#prodTag     = "FCCee/winter2023/IDEA/"
 
 #Input directory
 #Comment out when running over centrally produced events
 #Mandatory when running over privately produced events
-#inputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD"
-inputDir = "/eos/experiment/fcc/ee/analyses_storage/BSM/LLPs/ExoticHiggsDecays/MC_generation"
+#inputDir = "/eos/experiment/fcc/ee/analyses_storage/BSM/LLPs/ExoticHiggsDecays/MC_generation"
+inputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD"
 
 #Optional: output directory, default is local dir
-#outputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/Reco_output_stage1/"
-#outputDirEos = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/Reco_output_stage1/"
-outputDir = "/eos/experiment/fcc/ee/analyses_storage/BSM/LLPs/ExoticHiggsDecays/Reco_output_stage1/"
-#outputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD/Reco_output_stage1/"
+outputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD/Reco_output_stage1_H/"
 
 #Optional: ncpus, default is 4
 nCPUS       = 8
@@ -60,10 +49,11 @@ nCPUS       = 8
 runBatch    = True
 
 #Optional batch queue name when running on HTCondor, default is workday
-batchQueue = "workday"
+#batchQueue = "workday"
+batchQueue = "testmatch"
 
 #Optional computing account when running on HTCondor, default is group_u_FCC.local_gen
-#compGroup = "group_u_FCC.local_gen"
+compGroup = "group_u_FCC.local_gen"
 
 #USER DEFINED CODE
 # For costum displaced vertex selection, apply selection on the DVs with invariant mass higher than 1 GeV and distance from PV to DV less than 2000 mm, but longer than 4 mm
@@ -153,54 +143,55 @@ class RDFanalysis():
             .Define("Reco_DVs_merged_Lxy","VertexingUtils::get_dxy_SV(merged_DVs, PrimaryVertexObject)")
             .Define("Reco_DVs_merged_Lxyz","VertexingUtils::get_d3d_SV(merged_DVs, PrimaryVertexObject)")
 
-            # Reconstructed electrons and muons
-
-            # Electrons
-            .Alias('Electron0', 'Electron#0.index')
-            .Define('RecoElectrons',  'ReconstructedParticle::get(Electron0, ReconstructedParticles)') 
-            .Define('n_RecoElectrons',  'ReconstructedParticle::get_n(RecoElectrons)') #count how many electrons are in the event in total
-
-            # some kinematics of the reconstructed electrons and positrons
-            .Define("RecoElectron_e", "ReconstructedParticle::get_e(RecoElectrons)")
-            .Define("RecoElectron_p", "ReconstructedParticle::get_p(RecoElectrons)")
-            .Define("RecoElectron_pt", "ReconstructedParticle::get_pt(RecoElectrons)")
-            .Define("RecoElectron_px", "ReconstructedParticle::get_px(RecoElectrons)")
-            .Define("RecoElectron_py", "ReconstructedParticle::get_py(RecoElectrons)")
-            .Define("RecoElectron_pz", "ReconstructedParticle::get_pz(RecoElectrons)")
-            .Define("RecoElectron_charge",  "ReconstructedParticle::get_charge(RecoElectrons)")
-
-            # finding the invariant mass of the reconstructed electron and positron pair
-            .Define("Reco_ee_energy", "if ((n_RecoElectrons>1) && (RecoElectron_charge.at(0) != RecoElectron_charge.at(1))) return (RecoElectron_e.at(0) + RecoElectron_e.at(1)); else return float(-1.);")
-            .Define("Reco_ee_px", "if ((n_RecoElectrons>1) && (RecoElectron_charge.at(0) != RecoElectron_charge.at(1))) return (RecoElectron_px.at(0) + RecoElectron_px.at(1)); else return float(-1.);")
-            .Define("Reco_ee_py", "if ((n_RecoElectrons>1) && (RecoElectron_charge.at(0) != RecoElectron_charge.at(1))) return (RecoElectron_py.at(0) + RecoElectron_py.at(1)); else return float(-1.);")
-            .Define("Reco_ee_pz", "if ((n_RecoElectrons>1) && (RecoElectron_charge.at(0) != RecoElectron_charge.at(1))) return (RecoElectron_pz.at(0) + RecoElectron_pz.at(1)); else return float(-1.);")
-            .Define("Reco_ee_invMass", "if ((n_RecoElectrons>1) && (RecoElectron_charge.at(0) != RecoElectron_charge.at(1))) return sqrt(Reco_ee_energy*Reco_ee_energy - Reco_ee_px*Reco_ee_px - Reco_ee_py*Reco_ee_py - Reco_ee_pz*Reco_ee_pz ); else return float(-1.);")
-
-
-            # Muons
-            .Alias('Muon0', 'Muon#0.index')
-            .Define('RecoMuons',  'ReconstructedParticle::get(Muon0, ReconstructedParticles)')
-            .Define('n_RecoMuons',  'ReconstructedParticle::get_n(RecoMuons)') #count how many muons are in the event in total
-
-            # some kinematics of the reconstructed muons
-            .Define("RecoMuon_e",      "ReconstructedParticle::get_e(RecoMuons)")
-            .Define("RecoMuon_p",      "ReconstructedParticle::get_p(RecoMuons)")
-            .Define("RecoMuon_pt",      "ReconstructedParticle::get_pt(RecoMuons)")
-            .Define("RecoMuon_px",      "ReconstructedParticle::get_px(RecoMuons)")
-            .Define("RecoMuon_py",      "ReconstructedParticle::get_py(RecoMuons)")
-            .Define("RecoMuon_pz",      "ReconstructedParticle::get_pz(RecoMuons)")
-            .Define("RecoMuon_charge",  "ReconstructedParticle::get_charge(RecoMuons)")
-
-            # finding the invariant mass of the reconstructed muon pair
-            .Define("Reco_mumu_energy", "if ((n_RecoMuons>1) && (RecoMuon_charge.at(0) != RecoMuon_charge.at(1))) return (RecoMuon_e.at(0) + RecoMuon_e.at(1)); else return float(-1.);")
-            .Define("Reco_mumu_px", "if ((n_RecoMuons>1) && (RecoMuon_charge.at(0) != RecoMuon_charge.at(1))) return (RecoMuon_px.at(0) + RecoMuon_px.at(1)); else return float(-1.);")
-            .Define("Reco_mumu_py", "if ((n_RecoMuons>1) && (RecoMuon_charge.at(0) != RecoMuon_charge.at(1))) return (RecoMuon_py.at(0) + RecoMuon_py.at(1)); else return float(-1.);")
-            .Define("Reco_mumu_pz", "if ((n_RecoMuons>1) && (RecoMuon_charge.at(0) != RecoMuon_charge.at(1))) return (RecoMuon_pz.at(0) + RecoMuon_pz.at(1)); else return float(-1.);")
-            .Define("Reco_mumu_invMass", "if ((n_RecoMuons>1) && (RecoMuon_charge.at(0) != RecoMuon_charge.at(1))) return sqrt(Reco_mumu_energy*Reco_mumu_energy - Reco_mumu_px*Reco_mumu_px - Reco_mumu_py*Reco_mumu_py - Reco_mumu_pz*Reco_mumu_pz ); else return float(-1.);")
-
             # Number of DVs with distance and invariant mass selection applied
             .Define("filter_n_DVs_seltracks", "filter_n_DVs(Reco_seltracks_DVs_Lxyz, invMass_seltracks_DVs)")
             .Define("filter_n_DVs_merge", "filter_n_DVs(Reco_DVs_merged_Lxyz, invMass_merged_DVs)")
+
+            ##### Remove particles associated with DVs, then run N = 2 exclusive jet clustering
+
+            # get particle indices from dv tracks
+            #get_recoindTRK
+            #DV_evt_seltracks
+            .Define("rp_indices_DVs_trks", "VertexingUtils::get_VerticesRecoParticlesInd(DV_evt_seltracks, ReconstructedParticles)")
+            .Define("rp_DVs", "ReconstructedParticle::get(rp_indices_DVs_trks, ReconstructedParticles)")
+            .Define("nondv_recoparticles",  "ReconstructedParticle::remove( ReconstructedParticles,  rp_DVs )")
+
+            #define the RP px, py, pz and e
+            .Define("RP_px",          "ReconstructedParticle::get_px(nondv_recoparticles)")
+            .Define("RP_py",          "ReconstructedParticle::get_py(nondv_recoparticles)")
+            .Define("RP_pz",          "ReconstructedParticle::get_pz(nondv_recoparticles)")
+            .Define("RP_e",           "ReconstructedParticle::get_e(nondv_recoparticles)")
+            .Define("RP_m",           "ReconstructedParticle::get_mass(nondv_recoparticles)")
+            .Define("RP_q",           "ReconstructedParticle::get_charge(nondv_recoparticles)")
+
+            #build pseudo jets with the RP, using the interface that takes px,py,pz,m for better
+            #handling of rounding errors
+            .Define("pseudo_jets",    "JetClusteringUtils::set_pseudoJets_xyzm(RP_px, RP_py, RP_pz, RP_m)")
+
+            #run jet clustering with all reconstructed particles. kt_algorithm, R=0.5, exclusive clustering, exactly 2 jets, E0-scheme
+            .Define("FCCAnalysesJets_kt", "JetClustering::clustering_kt(0.5, 2, 2, 0, 10)(pseudo_jets)")
+            #get the jets out of the struct
+            .Define("jets_kt",           "JetClusteringUtils::get_pseudoJets(FCCAnalysesJets_kt)")
+            #get the jets constituents out of the struct
+            .Define("jetconstituents_kt","JetClusteringUtils::get_constituents(FCCAnalysesJets_kt)")
+            #get some variables
+            .Define("jets_kt_e",        "JetClusteringUtils::get_e(jets_kt)")
+            .Define("jets_kt_px",        "JetClusteringUtils::get_px(jets_kt)")
+            .Define("jets_kt_py",        "JetClusteringUtils::get_py(jets_kt)")
+            .Define("jets_kt_pz",        "JetClusteringUtils::get_pz(jets_kt)")
+            .Define("jets_kt_m",        "JetClusteringUtils::get_m(jets_kt)")
+            
+            .Define("jets_kt_e_sum",        "ReconstructedParticle::get_sum_float(jets_kt_e)")
+            .Define("jets_kt_px_sum",        "ReconstructedParticle::get_sum_float(jets_kt_px)")
+            .Define("jets_kt_py_sum",        "ReconstructedParticle::get_sum_float(jets_kt_py)")
+            .Define("jets_kt_pz_sum",        "ReconstructedParticle::get_sum_float(jets_kt_pz)")
+            .Define("jets_kt_m_sum",        "ReconstructedParticle::get_sum_float(jets_kt_m)")
+
+            .Define("jets_kt_e_avg",        "ReconstructedParticle::get_avg_float(jets_kt_e)")
+            .Define("jets_kt_px_avg",        "ReconstructedParticle::get_avg_float(jets_kt_px)")
+            .Define("jets_kt_py_avg",        "ReconstructedParticle::get_avg_float(jets_kt_py)")
+            .Define("jets_kt_pz_avg",        "ReconstructedParticle::get_avg_float(jets_kt_pz)")
+            .Define("jets_kt_m_avg",        "ReconstructedParticle::get_avg_float(jets_kt_m)")
 
         )
         return df2
@@ -229,26 +220,26 @@ class RDFanalysis():
             "Reco_DVs_merged_Lxy",
             "Reco_DVs_merged_Lxyz",
 
-            'n_RecoElectrons',
-            "RecoElectron_e",
-            "RecoElectron_p",
-            "RecoElectron_pt",
-            "RecoElectron_px",
-            "RecoElectron_py",
-            "RecoElectron_pz",
-            "RecoElectron_charge",
-            "Reco_ee_invMass",
-            'n_RecoMuons',
-            "RecoMuon_e",
-            "RecoMuon_p",
-            "RecoMuon_pt",
-            "RecoMuon_px",
-            "RecoMuon_py",
-            "RecoMuon_pz",
-            "RecoMuon_charge",
-            "Reco_mumu_invMass",
-
             "filter_n_DVs_seltracks",
             "filter_n_DVs_merge",
+
+            "jets_kt_e",
+            "jets_kt_px",
+            "jets_kt_py",
+            "jets_kt_pz",
+            "jets_kt_m",
+            "jetconstituents_kt",
+
+            "jets_kt_e_sum",
+            "jets_kt_px_sum",
+            "jets_kt_py_sum",
+            "jets_kt_pz_sum",
+            "jets_kt_m_sum",
+
+            "jets_kt_e_avg",
+            "jets_kt_px_avg",
+            "jets_kt_py_avg",
+            "jets_kt_pz_avg",
+            "jets_kt_m_avg"
         ]
         return branchList

--- a/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_stage1_NU.py
+++ b/examples/FCCee/bsm/LLPs/ExoticHiggsDecays/Reco_analysis_stage1_NU.py
@@ -1,56 +1,37 @@
 import ROOT
 
-testFile = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/output_MadgraphPythiaDelphes/exoticHiggs_scalar_ms20GeV_sine-6.root"
+testFile = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD/exoticHiggs_scalar_ms20GeV_sine-5_NU.root"
 
 #Mandatory: List of processes
 processList = {
 
         #privately-produced signals
-        'exoticHiggs_scalar_ms20GeV_sine-5':{},
-        'exoticHiggs_scalar_ms20GeV_sine-6':{},
-        'exoticHiggs_scalar_ms20GeV_sine-7':{},
-        'exoticHiggs_scalar_ms60GeV_sine-5':{},
-        'exoticHiggs_scalar_ms60GeV_sine-6':{},
-        'exoticHiggs_scalar_ms60GeV_sine-7':{},
-        #'exoticHiggs_scalar_ms20GeV_sine-5_CLD':{}, # CLD privately-produced signals 
-        #'exoticHiggs_scalar_ms20GeV_sine-6_CLD':{},
-        #'exoticHiggs_scalar_ms20GeV_sine-7_CLD':{},
-        #'exoticHiggs_scalar_ms60GeV_sine-5_CLD':{},
-        #'exoticHiggs_scalar_ms60GeV_sine-6_CLD':{},
-        #'exoticHiggs_scalar_ms60GeV_sine-7_CLD':{},
+        'exoticHiggs_scalar_ms20GeV_sine-5_NU':{},
+        'exoticHiggs_scalar_ms20GeV_sine-6_NU':{},
+        'exoticHiggs_scalar_ms20GeV_sine-7_NU':{},
+        'exoticHiggs_scalar_ms60GeV_sine-5_NU':{},
+        'exoticHiggs_scalar_ms60GeV_sine-6_NU':{},
+        'exoticHiggs_scalar_ms60GeV_sine-7_NU':{},
 
         # #centrally produced backgrounds
-        # IDEA backgrounds
-        # 'p8_ee_ZH_ecm240':{'fraction':0.01},
-        # 'p8_ee_ZZ_ecm240':{'fraction':0.01},   
-        # 'p8_ee_WW_ecm240':{'fraction':0.01},     
-        
-        # CLD (IDEA_FullSilicon) backgrounds
-        #'p8_ee_ZH_ecm240':{'fraction':0.01, 'chunks':5},
-        #'p8_ee_ZZ_ecm240':{'fraction':0.01, 'chunks':5},   
-        #'p8_ee_WW_ecm240':{'fraction':0.01, 'chunks':5},     
-        #'wzp6_ee_eeH_HZa_ecm240':{'fraction':0.01, 'chunks':5},   
-        #'wzp6_ee_mumuH_HZa_ecm240':{'fraction':0.01, 'chunks':5},   
+        #'p8_ee_ZZ_ecm240':{'fraction':0.005, 'chunks':5},   
+        #'p8_ee_WW_ecm240':{'fraction':0.005, 'chunks':5},     
+        #'wzp6_ee_nunuH_Hbb_ecm240':{'fraction':0.005, 'chunks':5},
+        #'wzp6_ee_nunuH_HWW_ecm240':{'fraction':0.005, 'chunks':5}
 }
 
 #Production tag. This points to the yaml files for getting sample statistics
 #Mandatory when running over EDM4Hep centrally produced events
 #Comment out when running over privately produced events
-#prodTag     = "FCCee/spring2021/IDEA/"
-#prodTag     = "FCCee/winter2023/IDEA_FullSilicon/"
-
+#prodTag     = "FCCee/winter2023/IDEA/"
 
 #Input directory
 #Comment out when running over centrally produced events
 #Mandatory when running over privately produced events
-#inputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD"
-inputDir = "/eos/experiment/fcc/ee/analyses_storage/BSM/LLPs/ExoticHiggsDecays/MC_generation"
+inputDir = "/eos/user/m/mlarson/exoticHiggsSamplesCLD"
 
 #Optional: output directory, default is local dir
-#outputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/Reco_output_stage1/"
-#outputDirEos = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/H_SS_4b/Reco_output_stage1/"
-outputDir = "/eos/experiment/fcc/ee/analyses_storage/BSM/LLPs/ExoticHiggsDecays/Reco_output_stage1/"
-#outputDir = "/eos/experiment/fcc/ee/analyses/case-studies/bsm/LLPs/exoticHiggsSamplesCLD/Reco_output_stage1/"
+outputDir = "/eos/user/m/mlarson/exoticHiggsSamplesCLD/Reco_output_stage1_NU"
 
 #Optional: ncpus, default is 4
 nCPUS       = 8
@@ -60,10 +41,10 @@ nCPUS       = 8
 runBatch    = True
 
 #Optional batch queue name when running on HTCondor, default is workday
-batchQueue = "workday"
+batchQueue = "testmatch"
 
 #Optional computing account when running on HTCondor, default is group_u_FCC.local_gen
-#compGroup = "group_u_FCC.local_gen"
+compGroup = "group_u_FCC.local_gen"
 
 #USER DEFINED CODE
 # For costum displaced vertex selection, apply selection on the DVs with invariant mass higher than 1 GeV and distance from PV to DV less than 2000 mm, but longer than 4 mm
@@ -153,54 +134,31 @@ class RDFanalysis():
             .Define("Reco_DVs_merged_Lxy","VertexingUtils::get_dxy_SV(merged_DVs, PrimaryVertexObject)")
             .Define("Reco_DVs_merged_Lxyz","VertexingUtils::get_d3d_SV(merged_DVs, PrimaryVertexObject)")
 
-            # Reconstructed electrons and muons
-
-            # Electrons
-            .Alias('Electron0', 'Electron#0.index')
-            .Define('RecoElectrons',  'ReconstructedParticle::get(Electron0, ReconstructedParticles)') 
-            .Define('n_RecoElectrons',  'ReconstructedParticle::get_n(RecoElectrons)') #count how many electrons are in the event in total
-
-            # some kinematics of the reconstructed electrons and positrons
-            .Define("RecoElectron_e", "ReconstructedParticle::get_e(RecoElectrons)")
-            .Define("RecoElectron_p", "ReconstructedParticle::get_p(RecoElectrons)")
-            .Define("RecoElectron_pt", "ReconstructedParticle::get_pt(RecoElectrons)")
-            .Define("RecoElectron_px", "ReconstructedParticle::get_px(RecoElectrons)")
-            .Define("RecoElectron_py", "ReconstructedParticle::get_py(RecoElectrons)")
-            .Define("RecoElectron_pz", "ReconstructedParticle::get_pz(RecoElectrons)")
-            .Define("RecoElectron_charge",  "ReconstructedParticle::get_charge(RecoElectrons)")
-
-            # finding the invariant mass of the reconstructed electron and positron pair
-            .Define("Reco_ee_energy", "if ((n_RecoElectrons>1) && (RecoElectron_charge.at(0) != RecoElectron_charge.at(1))) return (RecoElectron_e.at(0) + RecoElectron_e.at(1)); else return float(-1.);")
-            .Define("Reco_ee_px", "if ((n_RecoElectrons>1) && (RecoElectron_charge.at(0) != RecoElectron_charge.at(1))) return (RecoElectron_px.at(0) + RecoElectron_px.at(1)); else return float(-1.);")
-            .Define("Reco_ee_py", "if ((n_RecoElectrons>1) && (RecoElectron_charge.at(0) != RecoElectron_charge.at(1))) return (RecoElectron_py.at(0) + RecoElectron_py.at(1)); else return float(-1.);")
-            .Define("Reco_ee_pz", "if ((n_RecoElectrons>1) && (RecoElectron_charge.at(0) != RecoElectron_charge.at(1))) return (RecoElectron_pz.at(0) + RecoElectron_pz.at(1)); else return float(-1.);")
-            .Define("Reco_ee_invMass", "if ((n_RecoElectrons>1) && (RecoElectron_charge.at(0) != RecoElectron_charge.at(1))) return sqrt(Reco_ee_energy*Reco_ee_energy - Reco_ee_px*Reco_ee_px - Reco_ee_py*Reco_ee_py - Reco_ee_pz*Reco_ee_pz ); else return float(-1.);")
-
-
-            # Muons
-            .Alias('Muon0', 'Muon#0.index')
-            .Define('RecoMuons',  'ReconstructedParticle::get(Muon0, ReconstructedParticles)')
-            .Define('n_RecoMuons',  'ReconstructedParticle::get_n(RecoMuons)') #count how many muons are in the event in total
-
-            # some kinematics of the reconstructed muons
-            .Define("RecoMuon_e",      "ReconstructedParticle::get_e(RecoMuons)")
-            .Define("RecoMuon_p",      "ReconstructedParticle::get_p(RecoMuons)")
-            .Define("RecoMuon_pt",      "ReconstructedParticle::get_pt(RecoMuons)")
-            .Define("RecoMuon_px",      "ReconstructedParticle::get_px(RecoMuons)")
-            .Define("RecoMuon_py",      "ReconstructedParticle::get_py(RecoMuons)")
-            .Define("RecoMuon_pz",      "ReconstructedParticle::get_pz(RecoMuons)")
-            .Define("RecoMuon_charge",  "ReconstructedParticle::get_charge(RecoMuons)")
-
-            # finding the invariant mass of the reconstructed muon pair
-            .Define("Reco_mumu_energy", "if ((n_RecoMuons>1) && (RecoMuon_charge.at(0) != RecoMuon_charge.at(1))) return (RecoMuon_e.at(0) + RecoMuon_e.at(1)); else return float(-1.);")
-            .Define("Reco_mumu_px", "if ((n_RecoMuons>1) && (RecoMuon_charge.at(0) != RecoMuon_charge.at(1))) return (RecoMuon_px.at(0) + RecoMuon_px.at(1)); else return float(-1.);")
-            .Define("Reco_mumu_py", "if ((n_RecoMuons>1) && (RecoMuon_charge.at(0) != RecoMuon_charge.at(1))) return (RecoMuon_py.at(0) + RecoMuon_py.at(1)); else return float(-1.);")
-            .Define("Reco_mumu_pz", "if ((n_RecoMuons>1) && (RecoMuon_charge.at(0) != RecoMuon_charge.at(1))) return (RecoMuon_pz.at(0) + RecoMuon_pz.at(1)); else return float(-1.);")
-            .Define("Reco_mumu_invMass", "if ((n_RecoMuons>1) && (RecoMuon_charge.at(0) != RecoMuon_charge.at(1))) return sqrt(Reco_mumu_energy*Reco_mumu_energy - Reco_mumu_px*Reco_mumu_px - Reco_mumu_py*Reco_mumu_py - Reco_mumu_pz*Reco_mumu_pz ); else return float(-1.);")
-
             # Number of DVs with distance and invariant mass selection applied
             .Define("filter_n_DVs_seltracks", "filter_n_DVs(Reco_seltracks_DVs_Lxyz, invMass_seltracks_DVs)")
             .Define("filter_n_DVs_merge", "filter_n_DVs(Reco_DVs_merged_Lxyz, invMass_merged_DVs)")
+            
+            # MET (from displaced HNL analysis_stage1.py)
+            #EVENTWIDE VARIABLES: Access quantities that exist only once per event, such as the missing energy (despite the name, the MissingET collection contains the total missing energy)
+            .Define("RecoMissingEnergy_e", "ReconstructedParticle::get_e(MissingET)")
+            .Define("RecoMissingEnergy_p", "ReconstructedParticle::get_p(MissingET)")
+            .Define("RecoMissingEnergy_pt", "ReconstructedParticle::get_pt(MissingET)")
+            .Define("RecoMissingEnergy_px", "ReconstructedParticle::get_px(MissingET)") #x-component of RecoMissingEnergy
+            .Define("RecoMissingEnergy_py", "ReconstructedParticle::get_py(MissingET)") #y-component of RecoMissingEnergy
+            .Define("RecoMissingEnergy_pz", "ReconstructedParticle::get_pz(MissingET)") #z-component of RecoMissingEnergy
+            .Define("RecoMissingEnergy_eta", "ReconstructedParticle::get_eta(MissingET)")
+            .Define("RecoMissingEnergy_theta", "ReconstructedParticle::get_theta(MissingET)")
+            .Define("RecoMissingEnergy_phi", "ReconstructedParticle::get_phi(MissingET)") #angle of RecoMissingEnergy
+
+            .Define("RecoMissingEnergy_e_sum", "ReconstructedParticle::get_sum_float(RecoMissingEnergy_e)")
+            .Define("RecoMissingEnergy_p_sum", "ReconstructedParticle::get_sum_float(RecoMissingEnergy_p)")
+            .Define("RecoMissingEnergy_pt_sum", "ReconstructedParticle::get_sum_float(RecoMissingEnergy_pt)")
+            .Define("RecoMissingEnergy_px_sum", "ReconstructedParticle::get_sum_float(RecoMissingEnergy_px)") #x-component of RecoMissingEnergy
+            .Define("RecoMissingEnergy_py_sum", "ReconstructedParticle::get_sum_float(RecoMissingEnergy_py)") #y-component of RecoMissingEnergy
+            .Define("RecoMissingEnergy_pz_sum", "ReconstructedParticle::get_sum_float(RecoMissingEnergy_pz)") #z-component of RecoMissingEnergy
+            .Define("RecoMissingEnergy_eta_sum", "ReconstructedParticle::get_sum_float(RecoMissingEnergy_eta)")
+            .Define("RecoMissingEnergy_theta_sum", "ReconstructedParticle::get_sum_float(RecoMissingEnergy_theta)")
+            .Define("RecoMissingEnergy_phi_sum", "ReconstructedParticle::get_sum_float(RecoMissingEnergy_phi)") #angle of RecoMissingEnergy
 
         )
         return df2
@@ -229,26 +187,19 @@ class RDFanalysis():
             "Reco_DVs_merged_Lxy",
             "Reco_DVs_merged_Lxyz",
 
-            'n_RecoElectrons',
-            "RecoElectron_e",
-            "RecoElectron_p",
-            "RecoElectron_pt",
-            "RecoElectron_px",
-            "RecoElectron_py",
-            "RecoElectron_pz",
-            "RecoElectron_charge",
-            "Reco_ee_invMass",
-            'n_RecoMuons',
-            "RecoMuon_e",
-            "RecoMuon_p",
-            "RecoMuon_pt",
-            "RecoMuon_px",
-            "RecoMuon_py",
-            "RecoMuon_pz",
-            "RecoMuon_charge",
-            "Reco_mumu_invMass",
-
             "filter_n_DVs_seltracks",
             "filter_n_DVs_merge",
+
+            "RecoMissingEnergy_e_sum",
+            "RecoMissingEnergy_p_sum",
+            "RecoMissingEnergy_pt_sum",
+            "RecoMissingEnergy_px_sum",
+            "RecoMissingEnergy_py_sum",
+            "RecoMissingEnergy_pz_sum",
+            "RecoMissingEnergy_eta_sum",
+            "RecoMissingEnergy_theta_sum",
+            "RecoMissingEnergy_phi_sum"
+
+
         ]
         return branchList


### PR DESCRIPTION
Adds analysis scripts to process privately generated signal samples for Z --> qq, nu nu samples to increase signal statistics relative to original LLPs from exotic Higgs decays analysis. Also modifies existing analysis scripts to allow for processing privately generated leptonic Z decay signal samples using CLD (IDEA Full Silicon) detector card. Also adds some basic helper functions to change data types in stage 1 output file to be more easily worked with. 